### PR TITLE
Stream as a dimension for MultiStreaming and Stale leases deferred cleanup

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/ConfigsBuilder.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/ConfigsBuilder.java
@@ -124,7 +124,10 @@ public class ConfigsBuilder {
      * @param workerIdentifier
      * @param shardRecordProcessorFactory
      */
-    public ConfigsBuilder(@NonNull String streamName, @NonNull String applicationName, @NonNull KinesisAsyncClient kinesisClient, @NonNull DynamoDbAsyncClient dynamoDBClient, @NonNull CloudWatchAsyncClient cloudWatchClient, @NonNull String workerIdentifier, @NonNull ShardRecordProcessorFactory shardRecordProcessorFactory) {
+    public ConfigsBuilder(@NonNull String streamName, @NonNull String applicationName,
+            @NonNull KinesisAsyncClient kinesisClient, @NonNull DynamoDbAsyncClient dynamoDBClient,
+            @NonNull CloudWatchAsyncClient cloudWatchClient, @NonNull String workerIdentifier,
+            @NonNull ShardRecordProcessorFactory shardRecordProcessorFactory) {
         this.appStreamTracker = Either.right(streamName);
         this.applicationName = applicationName;
         this.kinesisClient = kinesisClient;
@@ -144,7 +147,10 @@ public class ConfigsBuilder {
      * @param workerIdentifier
      * @param shardRecordProcessorFactory
      */
-    public ConfigsBuilder(@NonNull MultiStreamTracker multiStreamTracker, @NonNull String applicationName, @NonNull KinesisAsyncClient kinesisClient, @NonNull DynamoDbAsyncClient dynamoDBClient, @NonNull CloudWatchAsyncClient cloudWatchClient, @NonNull String workerIdentifier, @NonNull ShardRecordProcessorFactory shardRecordProcessorFactory) {
+    public ConfigsBuilder(@NonNull MultiStreamTracker multiStreamTracker, @NonNull String applicationName,
+            @NonNull KinesisAsyncClient kinesisClient, @NonNull DynamoDbAsyncClient dynamoDBClient,
+            @NonNull CloudWatchAsyncClient cloudWatchClient, @NonNull String workerIdentifier,
+            @NonNull ShardRecordProcessorFactory shardRecordProcessorFactory) {
         this.appStreamTracker = Either.left(multiStreamTracker);
         this.applicationName = applicationName;
         this.kinesisClient = kinesisClient;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/RequestDetails.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/RequestDetails.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package software.amazon.kinesis.common;
 
 import lombok.experimental.Accessors;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/StreamConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/StreamConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package software.amazon.kinesis.common;
 
 import lombok.Value;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/StreamIdentifier.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/common/StreamIdentifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package software.amazon.kinesis.common;
 
 import com.google.common.base.Joiner;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -19,6 +19,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 
 import io.reactivex.plugins.RxJavaPlugins;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
+import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -98,6 +102,7 @@ import software.amazon.kinesis.retrieval.RetrievalConfig;
 public class Scheduler implements Runnable {
 
     private static final long NEW_STREAM_CHECK_INTERVAL_MILLIS = 1 * 60 * 1000L;
+    private static final long OLD_STREAM_DEFERRED_DELETION_PERIOD_MILLIS = 1 * 60 * 60 * 1000L;
 
     private SchedulerLog slog = new SchedulerLog();
 
@@ -132,7 +137,6 @@ public class Scheduler implements Runnable {
     private final long failoverTimeMillis;
     private final long taskBackoffTimeMillis;
     private final boolean isMultiStreamMode;
-    // TODO : halo : make sure we generate streamConfig if entry not present.
     private final Map<StreamIdentifier, StreamConfig> currentStreamConfigMap;
     private MultiStreamTracker multiStreamTracker;
     private final long listShardsBackoffTimeMillis;
@@ -143,6 +147,7 @@ public class Scheduler implements Runnable {
     private final AggregatorUtil aggregatorUtil;
     private final HierarchicalShardSyncer hierarchicalShardSyncer;
     private final long schedulerInitializationBackoffTimeMillis;
+    private final Map<StreamIdentifier, Instant> staleStreamDeletionMap = new HashMap<>();
 
     // Holds consumers for shards the worker is currently tracking. Key is shard
     // info, value is ShardConsumer.
@@ -232,8 +237,6 @@ public class Scheduler implements Runnable {
         this.executorService = this.coordinatorConfig.coordinatorFactory().createExecutorService();
         this.diagnosticEventFactory = diagnosticEventFactory;
         this.diagnosticEventHandler = new DiagnosticEventLogger();
-        // TODO : Halo : Handle case of no StreamConfig present in streamConfigList() for the supplied streamName.
-        // TODO : Pass the immutable map here instead of using mst.streamConfigList()
         this.shardSyncTaskManagerProvider = streamConfig -> this.leaseManagementConfig
                 .leaseManagementFactory(leaseSerializer, isMultiStreamMode)
                 .createShardSyncTaskManager(this.metricsFactory, streamConfig);
@@ -311,7 +314,7 @@ public class Scheduler implements Runnable {
                     if (!skipShardSyncAtWorkerInitializationIfLeasesExist || leaseRefresher.isLeaseTableEmpty()) {
                         // TODO: Resume the shard sync from failed stream in the next attempt, to avoid syncing
                         // TODO: for already synced streams
-                        for (Map.Entry<StreamIdentifier, StreamConfig> streamConfigEntry : currentStreamConfigMap.entrySet()) {
+                        for(Map.Entry<StreamIdentifier, StreamConfig> streamConfigEntry : currentStreamConfigMap.entrySet()) {
                             final StreamIdentifier streamIdentifier = streamConfigEntry.getKey();
                             log.info("Syncing Kinesis shard info for " + streamIdentifier);
                             final StreamConfig streamConfig = streamConfigEntry.getValue();
@@ -428,9 +431,16 @@ public class Scheduler implements Runnable {
             newStreamConfigMap.putAll(multiStreamTracker.streamConfigList().stream()
                     .collect(Collectors.toMap(sc -> sc.streamIdentifier(), sc -> sc)));
 
-            // This is done to ensure that we clean up the stale streams lingering in the lease table.
-            syncStreamsFromLeaseTableOnAppInit();
+            List<MultiStreamLease> leases;
 
+            // This is done to ensure that we clean up the stale streams lingering in the lease table.
+            if (!leasesSyncedOnAppInit && isMultiStreamMode) {
+                leases = fetchMultiStreamLeases();
+                syncStreamsFromLeaseTableOnAppInit(leases);
+                leasesSyncedOnAppInit = true;
+            }
+
+            // For new streams discovered, do a shard sync and update the currentStreamConfigMap
             for (StreamIdentifier streamIdentifier : newStreamConfigMap.keySet()) {
                 if (!currentStreamConfigMap.containsKey(streamIdentifier)) {
                     log.info("Found new stream to process: " + streamIdentifier + ". Syncing shards of that stream.");
@@ -445,21 +455,53 @@ public class Scheduler implements Runnable {
                 }
             }
 
-            // TODO: Remove assumption that each Worker gets the full list of streams
+            // Now, we are identifying the stale/old streams and enqueuing it for deferred deletion.
+            // It is assumed that all the workers will always have the latest and consistent snapshot of streams
+            // from the multiStreamTracker.
+            //
+            // The following streams transition state among two workers are NOT considered safe, where Worker 2, on
+            // initialization learn about D from lease table and delete the leases for D, as it is not available
+            // in its latest MultiStreamTracker.
+            // Worker 1 : A,B,C -> A,B,C,D (latest)
+            // Worker 2 : BOOTS_UP -> A,B,C (stale)
+            //
+            // The following streams transition state among two workers are NOT considered safe, where Worker 2 might
+            // end up deleting the leases for A and D and loose progress made so far.
+            // Worker 1 : A,B,C -> A,B,C,D (latest)
+            // Worker 2 : A,B,C -> B,C (stale/partial)
+            //
+            // In order to give workers with stale stream info, sufficient time to learn about the new streams
+            // before attempting to delete it, we will be deferring the leases deletion based on the
+            // defer time period.
+
             Iterator<StreamIdentifier> currentStreamConfigIter = currentStreamConfigMap.keySet().iterator();
             while (currentStreamConfigIter.hasNext()) {
                 StreamIdentifier streamIdentifier = currentStreamConfigIter.next();
                 if (!newStreamConfigMap.containsKey(streamIdentifier)) {
-                    log.info("Found old/deleted stream: " + streamIdentifier + ". Syncing shards of that stream.");
-                    ShardSyncTaskManager shardSyncTaskManager = createOrGetShardSyncTaskManager(currentStreamConfigMap.get(streamIdentifier));
-                    shardSyncTaskManager.syncShardAndLeaseInfo();
-                    currentStreamConfigIter.remove();
-                    streamsSynced.add(streamIdentifier);
+                    staleStreamDeletionMap.putIfAbsent(streamIdentifier, Instant.now());
                 }
             }
+
+            // Now let's scan the streamIdentifiers eligible for deferred deletion and delete them.
+            // StreamIdentifiers are eligible for deletion only when the deferment period has elapsed and
+            // the streamIdentifiers are not present in the latest snapshot.
+            final Set<StreamIdentifier> streamIdsToBeDeleted = staleStreamDeletionMap.keySet().stream()
+                    .filter(streamIdentifier ->
+                            Duration.between(staleStreamDeletionMap.get(streamIdentifier), Instant.now()).toMillis()
+                                    >= getOldStreamDeferredDeletionPeriodMillis() &&
+                                    !newStreamConfigMap.containsKey(streamIdentifier))
+                    .collect(Collectors.toSet());
+
+            streamsSynced.addAll(deleteMultiStreamLeases(streamIdsToBeDeleted));
+
             streamSyncWatch.reset().start();
         }
         return streamsSynced;
+    }
+
+    @VisibleForTesting
+    long getOldStreamDeferredDeletionPeriodMillis() {
+        return OLD_STREAM_DEFERRED_DELETION_PERIOD_MILLIS;
     }
 
     @VisibleForTesting
@@ -467,19 +509,63 @@ public class Scheduler implements Runnable {
         return isMultiStreamMode && (streamSyncWatch.elapsed(TimeUnit.MILLISECONDS) > NEW_STREAM_CHECK_INTERVAL_MILLIS);
     }
 
-    private void syncStreamsFromLeaseTableOnAppInit()
+    private void syncStreamsFromLeaseTableOnAppInit(List<MultiStreamLease> leases) {
+        final Set<StreamIdentifier> streamIdentifiers = leases.stream()
+                .map(lease -> StreamIdentifier.multiStreamInstance(lease.streamIdentifier()))
+                .collect(Collectors.toSet());
+        for (StreamIdentifier streamIdentifier : streamIdentifiers) {
+            if (!currentStreamConfigMap.containsKey(streamIdentifier)) {
+                currentStreamConfigMap.put(streamIdentifier, getDefaultStreamConfig(streamIdentifier));
+            }
+        }
+    }
+
+    private List<MultiStreamLease> fetchMultiStreamLeases()
             throws DependencyException, ProvisionedThroughputException, InvalidStateException {
-        if (!leasesSyncedOnAppInit && isMultiStreamMode) {
-            final Set<StreamIdentifier> streamIdentifiers = leaseCoordinator.leaseRefresher().listLeases().stream()
-                    .map(lease -> StreamIdentifier.multiStreamInstance(((MultiStreamLease) lease).streamIdentifier()))
-                    .collect(Collectors.toSet());
-            for (StreamIdentifier streamIdentifier : streamIdentifiers) {
-                if (!currentStreamConfigMap.containsKey(streamIdentifier)) {
-                    currentStreamConfigMap.put(streamIdentifier, getDefaultStreamConfig(streamIdentifier));
+        return (List<MultiStreamLease>) ((List) leaseCoordinator.leaseRefresher().listLeases());
+    }
+
+    private Set<StreamIdentifier> deleteMultiStreamLeases(Set<StreamIdentifier> streamIdentifiers)
+            throws DependencyException, ProvisionedThroughputException, InvalidStateException {
+        final Set<StreamIdentifier> streamsSynced = new HashSet<>();
+        List<MultiStreamLease> leases = null;
+        Map<String, List<MultiStreamLease>> streamIdToShardsMap = null;
+        for(StreamIdentifier streamIdentifier : streamIdentifiers) {
+            if (leases == null) {
+                // Lazy Load once and use many times for this iteration.
+                leases = fetchMultiStreamLeases();
+            }
+            if (streamIdToShardsMap == null) {
+                // Lazy load once and use many times for this iteration.
+                streamIdToShardsMap = leases.stream().collect(Collectors
+                        .groupingBy(MultiStreamLease::streamIdentifier,
+                                Collectors.toCollection(ArrayList::new)));
+            }
+            log.warn("Found old/deleted stream: " + streamIdentifier + ". Deleting leases of this stream.");
+            // Deleting leases will cause the workers to shutdown the record processors for these shards.
+            if (deleteMultiStreamLeases(streamIdToShardsMap.get(streamIdentifier.serialize()))) {
+                currentStreamConfigMap.remove(streamIdentifier);
+                staleStreamDeletionMap.remove(streamIdentifier);
+                streamsSynced.add(streamIdentifier);
+            }
+        }
+        return streamsSynced;
+    }
+
+    private boolean deleteMultiStreamLeases(List<MultiStreamLease> leases) {
+        if (leases != null) {
+            for (MultiStreamLease lease : leases) {
+                try {
+                    leaseRefresher.deleteLease(lease);
+                } catch (DependencyException | InvalidStateException | ProvisionedThroughputException e) {
+                    log.error(
+                            "Unable to delete stale stream lease {}. Skipping further deletions for this stream. Will retry later.",
+                            lease.leaseKey(), e);
+                    return false;
                 }
             }
-            leasesSyncedOnAppInit = true;
         }
+        return true;
     }
 
     // When a stream is no longer needed to be tracked, return a default StreamConfig with LATEST for faster shard end.
@@ -516,6 +602,7 @@ public class Scheduler implements Runnable {
      * Requests a graceful shutdown of the worker, notifying record processors, that implement
      * {@link ShutdownNotificationAware}, of the impending shutdown. This gives the record processor a final chance to
      * checkpoint.
+     *
      * This will only create a single shutdown future. Additional attempts to start a graceful shutdown will return the
      * previous future.
      *
@@ -542,8 +629,8 @@ public class Scheduler implements Runnable {
      * </ol>
      *
      * @return a future that will be set once the shutdown has completed. True indicates that the graceful shutdown
-     * completed successfully. A false value indicates that a non-exception case caused the shutdown process to
-     * terminate early.
+     *         completed successfully. A false value indicates that a non-exception case caused the shutdown process to
+     *         terminate early.
      */
     public Future<Boolean> startGracefulShutdown() {
         synchronized (this) {
@@ -560,8 +647,9 @@ public class Scheduler implements Runnable {
      * shutdowns in your own executor, or execute the shutdown synchronously.
      *
      * @return a callable that run the graceful shutdown process. This may return a callable that return true if the
-     * graceful shutdown has already been completed.
-     * @throws IllegalStateException thrown by the callable if another callable has already started the shutdown process.
+     *         graceful shutdown has already been completed.
+     * @throws IllegalStateException
+     *             thrown by the callable if another callable has already started the shutdown process.
      */
     public Callable<Boolean> createGracefulShutdownCallable() {
         if (shutdownComplete()) {
@@ -702,7 +790,8 @@ public class Scheduler implements Runnable {
     /**
      * NOTE: This method is internal/private to the Worker class. It has package access solely for testing.
      *
-     * @param shardInfo Kinesis shard info
+     * @param shardInfo
+     *            Kinesis shard info
      * @return ShardConsumer for the shard
      */
     ShardConsumer createOrGetShardConsumer(@NonNull final ShardInfo shardInfo,
@@ -730,7 +819,7 @@ public class Scheduler implements Runnable {
                                           @NonNull final ShardRecordProcessorFactory shardRecordProcessorFactory) {
         RecordsPublisher cache = retrievalConfig.retrievalFactory().createGetRecordsCache(shardInfo, metricsFactory);
         ShardRecordProcessorCheckpointer checkpointer = coordinatorConfig.coordinatorFactory().createRecordProcessorCheckpointer(shardInfo,
-                checkpoint);
+                        checkpoint);
         // The only case where streamName is not available will be when multistreamtracker not set. In this case,
         // get the default stream name for the single stream application.
         final StreamIdentifier streamIdentifier = getStreamIdentifier(shardInfo.streamIdentifierSerOpt());
@@ -767,6 +856,7 @@ public class Scheduler implements Runnable {
 
     /**
      * NOTE: This method is internal/private to the Worker class. It has package access solely for testing.
+     *
      * This method relies on ShardInfo.equals() method returning true for ShardInfo objects which may have been
      * instantiated with parentShardIds in a different order (and rest of the fields being the equal). For example
      * shardInfo1.equals(shardInfo2) should return true with shardInfo1 and shardInfo2 defined as follows. ShardInfo

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -485,14 +484,19 @@ public class Scheduler implements Runnable {
             // Now let's scan the streamIdentifiers eligible for deferred deletion and delete them.
             // StreamIdentifiers are eligible for deletion only when the deferment period has elapsed and
             // the streamIdentifiers are not present in the latest snapshot.
-            final Set<StreamIdentifier> streamIdsToBeDeleted = staleStreamDeletionMap.keySet().stream()
+            final Map<Boolean, Set<StreamIdentifier>> staleStreamIdDeletionDecisionMap = staleStreamDeletionMap.keySet()
+                    .stream().collect(Collectors
+                            .partitioningBy(streamIdentifier -> newStreamConfigMap.containsKey(streamIdentifier),
+                                    Collectors.toSet()));
+            final Set<StreamIdentifier> staleStreamIdsToBeDeleted = staleStreamIdDeletionDecisionMap.get(false).stream()
                     .filter(streamIdentifier ->
                             Duration.between(staleStreamDeletionMap.get(streamIdentifier), Instant.now()).toMillis()
-                                    >= getOldStreamDeferredDeletionPeriodMillis() &&
-                                    !newStreamConfigMap.containsKey(streamIdentifier))
-                    .collect(Collectors.toSet());
+                                    >= getOldStreamDeferredDeletionPeriodMillis()).collect(Collectors.toSet());
+            streamsSynced.addAll(deleteMultiStreamLeases(staleStreamIdsToBeDeleted));
 
-            streamsSynced.addAll(deleteMultiStreamLeases(streamIdsToBeDeleted));
+            // Purge the active streams from stale streams list.
+            final Set<StreamIdentifier> staleStreamIdsToBeRevived = staleStreamIdDeletionDecisionMap.get(true);
+            removeActiveStreamsFromStaleStreamsList(staleStreamIdsToBeRevived);
 
             streamSyncWatch.reset().start();
         }
@@ -523,6 +527,12 @@ public class Scheduler implements Runnable {
     private List<MultiStreamLease> fetchMultiStreamLeases()
             throws DependencyException, ProvisionedThroughputException, InvalidStateException {
         return (List<MultiStreamLease>) ((List) leaseCoordinator.leaseRefresher().listLeases());
+    }
+
+    private void removeActiveStreamsFromStaleStreamsList(Set<StreamIdentifier> streamIdentifiers) {
+        for(StreamIdentifier streamIdentifier : streamIdentifiers) {
+            staleStreamDeletionMap.remove(streamIdentifier);
+        }
     }
 
     private Set<StreamIdentifier> deleteMultiStreamLeases(Set<StreamIdentifier> streamIdentifiers)

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -38,6 +37,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
@@ -83,7 +83,11 @@ import software.amazon.kinesis.metrics.CloudWatchMetricsFactory;
 import software.amazon.kinesis.metrics.MetricsCollectingTaskDecorator;
 import software.amazon.kinesis.metrics.MetricsConfig;
 import software.amazon.kinesis.metrics.MetricsFactory;
+import software.amazon.kinesis.metrics.MetricsLevel;
+import software.amazon.kinesis.metrics.MetricsScope;
+import software.amazon.kinesis.metrics.MetricsUtil;
 import software.amazon.kinesis.processor.Checkpointer;
+import software.amazon.kinesis.processor.FormerStreamsLeasesDeletionStrategy;
 import software.amazon.kinesis.processor.MultiStreamTracker;
 import software.amazon.kinesis.processor.ProcessorConfig;
 import software.amazon.kinesis.processor.ShardRecordProcessorFactory;
@@ -91,6 +95,8 @@ import software.amazon.kinesis.processor.ShutdownNotificationAware;
 import software.amazon.kinesis.retrieval.AggregatorUtil;
 import software.amazon.kinesis.retrieval.RecordsPublisher;
 import software.amazon.kinesis.retrieval.RetrievalConfig;
+
+import static software.amazon.kinesis.processor.FormerStreamsLeasesDeletionStrategy.StreamsLeasesDeletionType;
 
 /**
  *
@@ -101,6 +107,10 @@ import software.amazon.kinesis.retrieval.RetrievalConfig;
 public class Scheduler implements Runnable {
 
     private static final long NEW_STREAM_CHECK_INTERVAL_MILLIS = 1 * 60 * 1000L;
+    private static final String MULTI_STREAM_TRACKER = "MultiStreamTracker";
+    private static final String ACTIVE_STREAMS_COUNT = "ActiveStreams.Count";
+    private static final String PENDING_STREAMS_DELETION_COUNT = "StreamsPendingDeletion.Count";
+    private static final String DELETED_STREAMS_COUNT = "DeletedStreams.Count";
 
     private SchedulerLog slog = new SchedulerLog();
 
@@ -137,6 +147,7 @@ public class Scheduler implements Runnable {
     private final boolean isMultiStreamMode;
     private final Map<StreamIdentifier, StreamConfig> currentStreamConfigMap;
     private MultiStreamTracker multiStreamTracker;
+    private FormerStreamsLeasesDeletionStrategy formerStreamsLeasesDeletionStrategy;
     private final long listShardsBackoffTimeMillis;
     private final int maxListShardsRetryAttempts;
     private final LeaseRefresher leaseRefresher;
@@ -205,6 +216,7 @@ public class Scheduler implements Runnable {
         this.currentStreamConfigMap = this.retrievalConfig.appStreamTracker().map(
                 multiStreamTracker -> {
                     this.multiStreamTracker = multiStreamTracker;
+                    this.formerStreamsLeasesDeletionStrategy = multiStreamTracker.formerStreamsLeasesDeletionStrategy();
                     return multiStreamTracker.streamConfigList().stream()
                             .collect(Collectors.toMap(sc -> sc.streamIdentifier(), sc -> sc));
                 },
@@ -424,92 +436,108 @@ public class Scheduler implements Runnable {
         final Set<StreamIdentifier> streamsSynced = new HashSet<>();
 
         if (shouldSyncStreamsNow()) {
-            final Map<StreamIdentifier, StreamConfig> newStreamConfigMap = new HashMap<>();
-            final Duration waitPeriodToDeleteOldStreams = multiStreamTracker.waitPeriodToDeleteOldStreams();
-            // Making an immutable copy
-            newStreamConfigMap.putAll(multiStreamTracker.streamConfigList().stream()
-                    .collect(Collectors.toMap(sc -> sc.streamIdentifier(), sc -> sc)));
+            final MetricsScope metricsScope = MetricsUtil.createMetricsWithOperation(metricsFactory, MULTI_STREAM_TRACKER);
 
-            List<MultiStreamLease> leases;
+            try {
 
-            // This is done to ensure that we clean up the stale streams lingering in the lease table.
-            if (!leasesSyncedOnAppInit && isMultiStreamMode) {
-                leases = fetchMultiStreamLeases();
-                syncStreamsFromLeaseTableOnAppInit(leases);
-                leasesSyncedOnAppInit = true;
-            }
+                final Map<StreamIdentifier, StreamConfig> newStreamConfigMap = new HashMap<>();
+                final Duration waitPeriodToDeleteOldStreams = formerStreamsLeasesDeletionStrategy.waitPeriodToDeleteFormerStreams();
+                // Making an immutable copy
+                newStreamConfigMap.putAll(multiStreamTracker.streamConfigList().stream()
+                        .collect(Collectors.toMap(sc -> sc.streamIdentifier(), sc -> sc)));
 
-            // For new streams discovered, do a shard sync and update the currentStreamConfigMap
-            for (StreamIdentifier streamIdentifier : newStreamConfigMap.keySet()) {
-                if (!currentStreamConfigMap.containsKey(streamIdentifier)) {
-                    log.info("Found new stream to process: " + streamIdentifier + ". Syncing shards of that stream.");
-                    ShardSyncTaskManager shardSyncTaskManager = createOrGetShardSyncTaskManager(newStreamConfigMap.get(streamIdentifier));
-                    shardSyncTaskManager.syncShardAndLeaseInfo();
-                    currentStreamConfigMap.put(streamIdentifier, newStreamConfigMap.get(streamIdentifier));
-                    streamsSynced.add(streamIdentifier);
-                } else {
-                    if (log.isDebugEnabled()) {
-                        log.debug(streamIdentifier + " is already being processed - skipping shard sync.");
+                List<MultiStreamLease> leases;
+
+                // This is done to ensure that we clean up the stale streams lingering in the lease table.
+                if (!leasesSyncedOnAppInit && isMultiStreamMode) {
+                    leases = fetchMultiStreamLeases();
+                    syncStreamsFromLeaseTableOnAppInit(leases);
+                    leasesSyncedOnAppInit = true;
+                }
+
+                // For new streams discovered, do a shard sync and update the currentStreamConfigMap
+                for (StreamIdentifier streamIdentifier : newStreamConfigMap.keySet()) {
+                    if (!currentStreamConfigMap.containsKey(streamIdentifier)) {
+                        log.info("Found new stream to process: " + streamIdentifier + ". Syncing shards of that stream.");
+                        ShardSyncTaskManager shardSyncTaskManager = createOrGetShardSyncTaskManager(newStreamConfigMap.get(streamIdentifier));
+                        shardSyncTaskManager.syncShardAndLeaseInfo();
+                        currentStreamConfigMap.put(streamIdentifier, newStreamConfigMap.get(streamIdentifier));
+                        streamsSynced.add(streamIdentifier);
+                    } else {
+                        if (log.isDebugEnabled()) {
+                            log.debug(streamIdentifier + " is already being processed - skipping shard sync.");
+                        }
                     }
                 }
-            }
 
-            // Now, we are identifying the stale/old streams and enqueuing it for deferred deletion.
-            // It is assumed that all the workers will always have the latest and consistent snapshot of streams
-            // from the multiStreamTracker.
-            //
-            // The following streams transition state among two workers are NOT considered safe, where Worker 2, on
-            // initialization learn about D from lease table and delete the leases for D, as it is not available
-            // in its latest MultiStreamTracker.
-            // Worker 1 : A,B,C -> A,B,C,D (latest)
-            // Worker 2 : BOOTS_UP -> A,B,C (stale)
-            //
-            // The following streams transition state among two workers are NOT considered safe, where Worker 2 might
-            // end up deleting the leases for A and D and loose progress made so far.
-            // Worker 1 : A,B,C -> A,B,C,D (latest)
-            // Worker 2 : A,B,C -> B,C (stale/partial)
-            //
-            // In order to give workers with stale stream info, sufficient time to learn about the new streams
-            // before attempting to delete it, we will be deferring the leases deletion based on the
-            // defer time period.
+                final Consumer<StreamIdentifier> enqueueStreamLeaseDeletionOperation = streamIdentifier -> {
+                    if (!newStreamConfigMap.containsKey(streamIdentifier)) {
+                        staleStreamDeletionMap.putIfAbsent(streamIdentifier, Instant.now());
+                    }
+                };
 
-            Iterator<StreamIdentifier> currentStreamConfigIter = currentStreamConfigMap.keySet().iterator();
-            while (currentStreamConfigIter.hasNext()) {
-                StreamIdentifier streamIdentifier = currentStreamConfigIter.next();
-                if (!newStreamConfigMap.containsKey(streamIdentifier)) {
-                    staleStreamDeletionMap.putIfAbsent(streamIdentifier, Instant.now());
+                if (formerStreamsLeasesDeletionStrategy.leaseDeletionType() == StreamsLeasesDeletionType.FORMER_STREAMS_AUTO_DETECTION_DEFERRED_DELETION) {
+                    // Now, we are identifying the stale/old streams and enqueuing it for deferred deletion.
+                    // It is assumed that all the workers will always have the latest and consistent snapshot of streams
+                    // from the multiStreamTracker.
+                    //
+                    // The following streams transition state among two workers are NOT considered safe, where Worker 2, on
+                    // initialization learn about D from lease table and delete the leases for D, as it is not available
+                    // in its latest MultiStreamTracker.
+                    // Worker 1 : A,B,C -> A,B,C,D (latest)
+                    // Worker 2 : BOOTS_UP -> A,B,C (stale)
+                    //
+                    // The following streams transition state among two workers are NOT considered safe, where Worker 2 might
+                    // end up deleting the leases for A and D and loose progress made so far.
+                    // Worker 1 : A,B,C -> A,B,C,D (latest)
+                    // Worker 2 : A,B,C -> B,C (stale/partial)
+                    //
+                    // In order to give workers with stale stream info, sufficient time to learn about the new streams
+                    // before attempting to delete it, we will be deferring the leases deletion based on the
+                    // defer time period.
+
+                    currentStreamConfigMap.keySet().stream().forEach(streamIdentifier -> enqueueStreamLeaseDeletionOperation.accept(streamIdentifier));
+
+                } else if (formerStreamsLeasesDeletionStrategy.leaseDeletionType() == StreamsLeasesDeletionType.PROVIDED_STREAMS_DEFERRED_DELETION) {
+                    Optional.ofNullable(formerStreamsLeasesDeletionStrategy.streamIdentifiers()).ifPresent(
+                            streamIdentifiers -> streamIdentifiers.stream().forEach(streamIdentifier -> enqueueStreamLeaseDeletionOperation.accept(streamIdentifier)));
                 }
+
+                // Now let's scan the streamIdentifiers eligible for deferred deletion and delete them.
+                // StreamIdentifiers are eligible for deletion only when the deferment period has elapsed and
+                // the streamIdentifiers are not present in the latest snapshot.
+                final Map<Boolean, Set<StreamIdentifier>> staleStreamIdDeletionDecisionMap = staleStreamDeletionMap.keySet().stream().collect(Collectors
+                        .partitioningBy(streamIdentifier -> newStreamConfigMap.containsKey(streamIdentifier), Collectors.toSet()));
+                final Set<StreamIdentifier> staleStreamIdsToBeDeleted = staleStreamIdDeletionDecisionMap.get(false).stream().filter(streamIdentifier ->
+                        Duration.between(staleStreamDeletionMap.get(streamIdentifier), Instant.now()).toMillis() >= waitPeriodToDeleteOldStreams.toMillis()).collect(Collectors.toSet());
+                final Set<StreamIdentifier> deletedStreamsLeases = deleteMultiStreamLeases(staleStreamIdsToBeDeleted);
+                streamsSynced.addAll(deletedStreamsLeases);
+
+                // Purge the active streams from stale streams list.
+                final Set<StreamIdentifier> staleStreamIdsToBeRevived = staleStreamIdDeletionDecisionMap.get(true);
+                removeStreamsFromStaleStreamsList(staleStreamIdsToBeRevived);
+
+                log.warn(
+                        "Streams enqueued for deletion for lease table cleanup along with their scheduled time for deletion: {} ",
+                        staleStreamDeletionMap.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
+                                entry -> entry.getValue().plus(waitPeriodToDeleteOldStreams))));
+
+                streamSyncWatch.reset().start();
+
+                MetricsUtil.addCount(metricsScope, ACTIVE_STREAMS_COUNT, newStreamConfigMap.size(), MetricsLevel.SUMMARY);
+                MetricsUtil.addCount(metricsScope, PENDING_STREAMS_DELETION_COUNT, staleStreamDeletionMap.size(),
+                        MetricsLevel.SUMMARY);
+                MetricsUtil.addCount(metricsScope, DELETED_STREAMS_COUNT, deletedStreamsLeases.size(), MetricsLevel.SUMMARY);
+            } finally {
+                MetricsUtil.endScope(metricsScope);
             }
-
-            // Now let's scan the streamIdentifiers eligible for deferred deletion and delete them.
-            // StreamIdentifiers are eligible for deletion only when the deferment period has elapsed and
-            // the streamIdentifiers are not present in the latest snapshot.
-            final Map<Boolean, Set<StreamIdentifier>> staleStreamIdDeletionDecisionMap = staleStreamDeletionMap.keySet()
-                    .stream().collect(Collectors
-                            .partitioningBy(streamIdentifier -> newStreamConfigMap.containsKey(streamIdentifier),
-                                    Collectors.toSet()));
-            final Set<StreamIdentifier> staleStreamIdsToBeDeleted = staleStreamIdDeletionDecisionMap.get(false).stream()
-                    .filter(streamIdentifier ->
-                            Duration.between(staleStreamDeletionMap.get(streamIdentifier), Instant.now()).toMillis()
-                                    >= waitPeriodToDeleteOldStreams.toMillis()).collect(Collectors.toSet());
-            streamsSynced.addAll(deleteMultiStreamLeases(staleStreamIdsToBeDeleted));
-
-            // Purge the active streams from stale streams list.
-            final Set<StreamIdentifier> staleStreamIdsToBeRevived = staleStreamIdDeletionDecisionMap.get(true);
-            removeActiveStreamsFromStaleStreamsList(staleStreamIdsToBeRevived);
-
-            log.warn("Streams enqueued for deletion for lease table cleanup along with their scheduled time for deletion: {} ",
-                    staleStreamDeletionMap.entrySet().stream().collect(Collectors
-                            .toMap(Map.Entry::getKey, entry -> entry.getValue().plus(waitPeriodToDeleteOldStreams))));
-
-            streamSyncWatch.reset().start();
         }
         return streamsSynced;
     }
 
-    @VisibleForTesting
-    boolean shouldSyncStreamsNow() {
-        return isMultiStreamMode && (streamSyncWatch.elapsed(TimeUnit.MILLISECONDS) > NEW_STREAM_CHECK_INTERVAL_MILLIS);
+    @VisibleForTesting boolean shouldSyncStreamsNow() {
+        return isMultiStreamMode &&
+                (streamSyncWatch.elapsed(TimeUnit.MILLISECONDS) > NEW_STREAM_CHECK_INTERVAL_MILLIS);
     }
 
     private void syncStreamsFromLeaseTableOnAppInit(List<MultiStreamLease> leases) {
@@ -528,7 +556,7 @@ public class Scheduler implements Runnable {
         return (List<MultiStreamLease>) ((List) leaseCoordinator.leaseRefresher().listLeases());
     }
 
-    private void removeActiveStreamsFromStaleStreamsList(Set<StreamIdentifier> streamIdentifiers) {
+    private void removeStreamsFromStaleStreamsList(Set<StreamIdentifier> streamIdentifiers) {
         for(StreamIdentifier streamIdentifier : streamIdentifiers) {
             staleStreamDeletionMap.remove(streamIdentifier);
         }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/coordinator/Scheduler.java
@@ -425,8 +425,7 @@ public class Scheduler implements Runnable {
 
         if (shouldSyncStreamsNow()) {
             final Map<StreamIdentifier, StreamConfig> newStreamConfigMap = new HashMap<>();
-            final long waitPeriodToDeleteOldStreamsMillis = multiStreamTracker.waitPeriodToDeleteOldStreams()
-                    .toMillis();
+            final Duration waitPeriodToDeleteOldStreams = multiStreamTracker.waitPeriodToDeleteOldStreams();
             // Making an immutable copy
             newStreamConfigMap.putAll(multiStreamTracker.streamConfigList().stream()
                     .collect(Collectors.toMap(sc -> sc.streamIdentifier(), sc -> sc)));
@@ -492,12 +491,16 @@ public class Scheduler implements Runnable {
             final Set<StreamIdentifier> staleStreamIdsToBeDeleted = staleStreamIdDeletionDecisionMap.get(false).stream()
                     .filter(streamIdentifier ->
                             Duration.between(staleStreamDeletionMap.get(streamIdentifier), Instant.now()).toMillis()
-                                    >= waitPeriodToDeleteOldStreamsMillis).collect(Collectors.toSet());
+                                    >= waitPeriodToDeleteOldStreams.toMillis()).collect(Collectors.toSet());
             streamsSynced.addAll(deleteMultiStreamLeases(staleStreamIdsToBeDeleted));
 
             // Purge the active streams from stale streams list.
             final Set<StreamIdentifier> staleStreamIdsToBeRevived = staleStreamIdDeletionDecisionMap.get(true);
             removeActiveStreamsFromStaleStreamsList(staleStreamIdsToBeRevived);
+
+            log.warn("Streams enqueued for deletion for lease table cleanup along with their scheduled time for deletion: {} ",
+                    staleStreamDeletionMap.entrySet().stream().collect(Collectors
+                            .toMap(Map.Entry::getKey, entry -> entry.getValue().plus(waitPeriodToDeleteOldStreams))));
 
             streamSyncWatch.reset().start();
         }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/MultiStreamLease.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/MultiStreamLease.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package software.amazon.kinesis.leases;
 
 import lombok.EqualsAndHashCode;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRenewer.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBLeaseRenewer.java
@@ -36,9 +36,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
+import software.amazon.kinesis.common.StreamIdentifier;
 import software.amazon.kinesis.leases.Lease;
 import software.amazon.kinesis.leases.LeaseRefresher;
 import software.amazon.kinesis.leases.LeaseRenewer;
+import software.amazon.kinesis.leases.MultiStreamLease;
 import software.amazon.kinesis.leases.exceptions.DependencyException;
 import software.amazon.kinesis.leases.exceptions.InvalidStateException;
 import software.amazon.kinesis.leases.exceptions.ProvisionedThroughputException;
@@ -297,6 +299,10 @@ public class DynamoDBLeaseRenewer implements LeaseRenewer {
 
         final MetricsScope scope = MetricsUtil.createMetricsWithOperation(metricsFactory, operation);
         if (StringUtils.isNotEmpty(shardId)) {
+            if(lease instanceof MultiStreamLease) {
+                MetricsUtil.addStreamId(scope,
+                        StreamIdentifier.multiStreamInstance(((MultiStreamLease) lease).streamIdentifier()));
+            }
             MetricsUtil.addShardId(scope, shardId);
         }
 

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBMultiStreamLeaseSerializer.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/dynamodb/DynamoDBMultiStreamLeaseSerializer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package software.amazon.kinesis.leases.dynamodb;
 
 import lombok.NoArgsConstructor;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ProcessTask.java
@@ -23,6 +23,7 @@ import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
 import software.amazon.awssdk.services.kinesis.model.Shard;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.checkpoint.ShardRecordProcessorCheckpointer;
+import software.amazon.kinesis.common.StreamIdentifier;
 import software.amazon.kinesis.leases.ShardDetector;
 import software.amazon.kinesis.leases.ShardInfo;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
@@ -109,6 +110,8 @@ public class ProcessTask implements ConsumerTask {
     @Override
     public TaskResult call() {
         final MetricsScope scope = MetricsUtil.createMetricsWithOperation(metricsFactory, PROCESS_TASK_OPERATION);
+        shardInfo.streamIdentifierSerOpt()
+                .ifPresent(streamId -> MetricsUtil.addStreamId(scope, StreamIdentifier.multiStreamInstance(streamId)));
         MetricsUtil.addShardId(scope, shardInfo.shardId());
         long startTimeMillis = System.currentTimeMillis();
         boolean success = false;
@@ -197,6 +200,8 @@ public class ProcessTask implements ConsumerTask {
                 .checkpointer(recordProcessorCheckpointer).millisBehindLatest(input.millisBehindLatest()).build();
 
         final MetricsScope scope = MetricsUtil.createMetricsWithOperation(metricsFactory, PROCESS_TASK_OPERATION);
+        shardInfo.streamIdentifierSerOpt()
+                .ifPresent(streamId -> MetricsUtil.addStreamId(scope, StreamIdentifier.multiStreamInstance(streamId)));
         MetricsUtil.addShardId(scope, shardInfo.shardId());
         final long startTime = System.currentTimeMillis();
         try {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/metrics/MetricsUtil.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/metrics/MetricsUtil.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import lombok.NonNull;
 import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
+import software.amazon.kinesis.common.StreamIdentifier;
 
 /**
  *
@@ -26,6 +27,7 @@ import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
 public class MetricsUtil {
     public static final String OPERATION_DIMENSION_NAME = "Operation";
     public static final String SHARD_ID_DIMENSION_NAME = "ShardId";
+    public static final String STREAM_IDENTIFIER = "StreamId";
     private static final String WORKER_IDENTIFIER_DIMENSION = "WorkerIdentifier";
     private static final String TIME_METRIC = "Time";
     private static final String SUCCESS_METRIC = "Success";
@@ -49,6 +51,11 @@ public class MetricsUtil {
 
     public static void addShardId(@NonNull final MetricsScope metricsScope, @NonNull final String shardId) {
         addOperation(metricsScope, SHARD_ID_DIMENSION_NAME, shardId);
+    }
+
+    public static void addStreamId(@NonNull final MetricsScope metricsScope, @NonNull final StreamIdentifier streamId) {
+        streamId.accountIdOptional()
+                .ifPresent(acc -> addOperation(metricsScope, STREAM_IDENTIFIER, streamId.serialize()));
     }
 
     public static void addWorkerIdentifier(@NonNull final MetricsScope metricsScope,

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/metrics/MetricsUtil.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/metrics/MetricsUtil.java
@@ -94,6 +94,11 @@ public class MetricsUtil {
         metricsScope.addData(metricName, success ? 1 : 0, StandardUnit.COUNT, metricsLevel);
     }
 
+    public static void addCount(@NonNull final MetricsScope metricsScope, final String dimension,
+            final long count, @NonNull final MetricsLevel metricsLevel) {
+        metricsScope.addData(dimension, count, StandardUnit.COUNT, metricsLevel);
+    }
+
     public static void endScope(@NonNull final MetricsScope metricsScope) {
         metricsScope.end();
     }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/FormerStreamsLeasesDeletionStrategy.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/FormerStreamsLeasesDeletionStrategy.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.processor;
+
+import software.amazon.kinesis.common.StreamIdentifier;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * Strategy for cleaning up the leases for former streams.
+ */
+public interface FormerStreamsLeasesDeletionStrategy {
+
+    /**
+     * StreamIdentifiers for which leases needs to be cleaned up in the lease table.
+     * @return
+     */
+    List<StreamIdentifier> streamIdentifiers();
+
+    /**
+     * Duration to wait before deleting the leases for this stream.
+     * @return
+     */
+    Duration waitPeriodToDeleteFormerStreams();
+
+    /**
+     * Strategy type for deleting the leases of former streams
+     * @return
+     */
+    StreamsLeasesDeletionType leaseDeletionType();
+
+    /**
+     * StreamsLeasesDeletionType identifying the different lease cleanup strategies.
+     */
+    enum StreamsLeasesDeletionType {
+        NO_STREAMS_LEASES_DELETION,
+        FORMER_STREAMS_AUTO_DETECTION_DEFERRED_DELETION,
+        PROVIDED_STREAMS_DEFERRED_DELETION
+    }
+
+    /**
+     * Strategy for not cleaning up leases for former streams.
+     */
+    final class NoLeaseDeletionStrategy implements FormerStreamsLeasesDeletionStrategy {
+
+        @Override
+        public final List<StreamIdentifier> streamIdentifiers() {
+            throw new UnsupportedOperationException("StreamIdentifiers not required");
+        }
+
+        @Override
+        public final Duration waitPeriodToDeleteFormerStreams() {
+            return Duration.ZERO;
+        }
+
+        @Override
+        public final StreamsLeasesDeletionType leaseDeletionType() {
+            return StreamsLeasesDeletionType.NO_STREAMS_LEASES_DELETION;
+        }
+    }
+
+    /**
+     * Strategy for auto detection the old of former streams based on the {@link MultiStreamTracker#streamConfigList()}
+     * and do deferred deletion based on {@link #waitPeriodToDeleteFormerStreams()}
+     */
+    abstract class AutoDetectionAndDeferredDeletionStrategy implements FormerStreamsLeasesDeletionStrategy {
+
+        @Override
+        public final List<StreamIdentifier> streamIdentifiers() {
+            throw new UnsupportedOperationException("StreamIdentifiers not required");
+        }
+
+        @Override
+        public final StreamsLeasesDeletionType leaseDeletionType() {
+            return StreamsLeasesDeletionType.FORMER_STREAMS_AUTO_DETECTION_DEFERRED_DELETION;
+        }
+    }
+
+    /**
+     * Strategy to detect the streams for deletion through {@link #streamIdentifiers()} provided by customer at runtime
+     * and do deferred deletion based on {@link #waitPeriodToDeleteFormerStreams()}
+     */
+    abstract class ProvidedStreamsDeferredDeletionStrategy implements FormerStreamsLeasesDeletionStrategy {
+
+        @Override
+        public final StreamsLeasesDeletionType leaseDeletionType() {
+            return StreamsLeasesDeletionType.PROVIDED_STREAMS_DEFERRED_DELETION;
+        }
+    }
+
+}
+
+
+
+

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/MultiStreamTracker.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/MultiStreamTracker.java
@@ -1,20 +1,43 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package software.amazon.kinesis.processor;
 
 import software.amazon.kinesis.common.StreamConfig;
 
+import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Interface for stream trackers. This is useful for KCL Workers that need
  * to consume data from multiple streams.
+ * KCL will periodically probe this interface to learn about the new and old streams.
  */
 public interface MultiStreamTracker {
 
     /**
      * Returns the list of stream config, to be processed by the current application.
+     * Note that this method will be called periodically called by the KCL to learn about the new and old streams.
      *
      * @return List of StreamConfig
      */
     List<StreamConfig> streamConfigList();
+
+    /**
+     * Duration to wait before deleting the old streams in the lease table.
+     * @return Wait time before deleting old streams
+     */
+    Duration waitPeriodToDeleteOldStreams();
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/MultiStreamTracker.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/processor/MultiStreamTracker.java
@@ -17,7 +17,6 @@ package software.amazon.kinesis.processor;
 
 import software.amazon.kinesis.common.StreamConfig;
 
-import java.time.Duration;
 import java.util.List;
 
 /**
@@ -29,15 +28,18 @@ public interface MultiStreamTracker {
 
     /**
      * Returns the list of stream config, to be processed by the current application.
-     * Note that this method will be called periodically called by the KCL to learn about the new and old streams.
+     * <b>Note that the streams list CAN be changed during the application runtime.</b>
+     * This method will be called periodically by the KCL to learn about the change in streams to process.
      *
      * @return List of StreamConfig
      */
     List<StreamConfig> streamConfigList();
 
     /**
-     * Duration to wait before deleting the old streams in the lease table.
-     * @return Wait time before deleting old streams
+     * Strategy to delete leases of old streams in the lease table.
+     * <b>Note that the strategy CANNOT be changed during the application runtime.</b>
+     *
+     * @return StreamsLeasesDeletionStrategy
      */
-    Duration waitPeriodToDeleteOldStreams();
+    FormerStreamsLeasesDeletionStrategy formerStreamsLeasesDeletionStrategy();
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/fanout/FanOutConfig.java
@@ -85,7 +85,7 @@ public class FanOutConfig implements RetrievalSpecificConfig {
         return new FanOutRetrievalFactory(kinesisClient, streamName, this::getOrCreateConsumerArn);
     }
 
-    // TODO : Halo. Need Stream Specific ConsumerArn to be passed from Customer
+    // TODO : LTR. Need Stream Specific ConsumerArn to be passed from Customer
     private String getOrCreateConsumerArn(String streamName) {
         if (consumerArn != null) {
             return consumerArn;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/KinesisDataFetcher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/KinesisDataFetcher.java
@@ -316,7 +316,7 @@ public class KinesisDataFetcher implements DataFetcher {
         } catch (ExecutionException e) {
             throw exceptionManager.apply(e.getCause());
         } catch (InterruptedException e) {
-            // TODO: Check behaviorF
+            // TODO: Check behavior
             log.debug("{} : Interrupt called on method, shutdown initiated", streamAndShardId);
             throw new RuntimeException(e);
         } catch (TimeoutException e) {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/KinesisDataFetcher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/KinesisDataFetcher.java
@@ -227,6 +227,7 @@ public class KinesisDataFetcher implements DataFetcher {
 
         // TODO: Check if this metric is fine to be added
         final MetricsScope metricsScope = MetricsUtil.createMetricsWithOperation(metricsFactory, OPERATION);
+        MetricsUtil.addStreamId(metricsScope, streamIdentifier);
         MetricsUtil.addShardId(metricsScope, shardId);
         boolean success = false;
         long startTime = System.currentTimeMillis();
@@ -304,6 +305,7 @@ public class KinesisDataFetcher implements DataFetcher {
         GetRecordsRequest request = getGetRecordsRequest(nextIterator);
 
         final MetricsScope metricsScope = MetricsUtil.createMetricsWithOperation(metricsFactory, OPERATION);
+        MetricsUtil.addStreamId(metricsScope, streamIdentifier);
         MetricsUtil.addShardId(metricsScope, shardId);
         boolean success = false;
         long startTime = System.currentTimeMillis();
@@ -314,7 +316,7 @@ public class KinesisDataFetcher implements DataFetcher {
         } catch (ExecutionException e) {
             throw exceptionManager.apply(e.getCause());
         } catch (InterruptedException e) {
-            // TODO: Check behavior
+            // TODO: Check behaviorF
             log.debug("{} : Interrupt called on method, shutdown initiated", streamAndShardId);
             throw new RuntimeException(e);
         } catch (TimeoutException e) {

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisher.java
@@ -45,6 +45,7 @@ import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
 import software.amazon.kinesis.common.RequestDetails;
+import software.amazon.kinesis.common.StreamIdentifier;
 import software.amazon.kinesis.lifecycle.events.ProcessRecordsInput;
 import software.amazon.kinesis.metrics.MetricsFactory;
 import software.amazon.kinesis.metrics.MetricsLevel;
@@ -88,6 +89,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
     private final DefaultGetRecordsCacheDaemon defaultGetRecordsCacheDaemon;
     private boolean started = false;
     private final String operation;
+    private final StreamIdentifier streamId;
     private final String streamAndShardId;
     private Subscriber<? super RecordsRetrieved> subscriber;
     @VisibleForTesting @Getter
@@ -219,8 +221,8 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
         this.defaultGetRecordsCacheDaemon = new DefaultGetRecordsCacheDaemon();
         Validate.notEmpty(operation, "Operation cannot be empty");
         this.operation = operation;
-        this.streamAndShardId =
-                this.getRecordsRetrievalStrategy.dataFetcher().getStreamIdentifier().serialize() + ":" + shardId;
+        this.streamId = this.getRecordsRetrievalStrategy.dataFetcher().getStreamIdentifier();
+        this.streamAndShardId = this.streamId.serialize() + ":" + shardId;
     }
 
     @Override
@@ -452,6 +454,7 @@ public class PrefetchRecordsPublisher implements RecordsPublisher {
                     log.info("{} :  records threw ExpiredIteratorException - restarting"
                             + " after greatest seqNum passed to customer", streamAndShardId, e);
 
+                    MetricsUtil.addStreamId(scope, streamId);
                     scope.addData(EXPIRED_ITERATOR_METRIC, 1, StandardUnit.COUNT, MetricsLevel.SUMMARY);
 
                     publisherSession.dataFetcher().restartIterator();

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.atMost;
 
-import java.time.Instant;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,7 +48,6 @@ import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
@@ -64,8 +63,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
-import software.amazon.awssdk.utils.Either;
-import software.amazon.awssdk.utils.Validate;
 import software.amazon.kinesis.checkpoint.Checkpoint;
 import software.amazon.kinesis.checkpoint.CheckpointConfig;
 import software.amazon.kinesis.checkpoint.CheckpointFactory;
@@ -180,6 +177,7 @@ public class SchedulerTest {
         }};
 
         when(multiStreamTracker.streamConfigList()).thenReturn(streamConfigList);
+        when(multiStreamTracker.waitPeriodToDeleteOldStreams()).thenReturn(Duration.ofHours(1L));
         when(leaseCoordinator.leaseRefresher()).thenReturn(dynamoDBLeaseRefresher);
         when(shardSyncTaskManager.shardDetector()).thenReturn(shardDetector);
         when(retrievalFactory.createGetRecordsCache(any(ShardInfo.class), any(MetricsFactory.class))).thenReturn(recordsPublisher);
@@ -485,7 +483,7 @@ public class SchedulerTest {
         scheduler = spy(new Scheduler(checkpointConfig, coordinatorConfig, leaseManagementConfig, lifecycleConfig,
                 metricsConfig, processorConfig, retrievalConfig));
         when(scheduler.shouldSyncStreamsNow()).thenReturn(true);
-        when(scheduler.getOldStreamDeferredDeletionPeriodMillis()).thenReturn(0L);
+        when(multiStreamTracker.waitPeriodToDeleteOldStreams()).thenReturn(Duration.ZERO);
         Set<StreamIdentifier> syncedStreams = scheduler.checkAndSyncStreamShardsAndLeases();
         Set<StreamIdentifier> expectedSyncedStreams = IntStream.range(1, 3).mapToObj(streamId -> StreamIdentifier.multiStreamInstance(
                 Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345))).collect(
@@ -556,7 +554,7 @@ public class SchedulerTest {
         scheduler = spy(new Scheduler(checkpointConfig, coordinatorConfig, leaseManagementConfig, lifecycleConfig,
                 metricsConfig, processorConfig, retrievalConfig));
         when(scheduler.shouldSyncStreamsNow()).thenReturn(true);
-        when(scheduler.getOldStreamDeferredDeletionPeriodMillis()).thenReturn(0L);
+        when(multiStreamTracker.waitPeriodToDeleteOldStreams()).thenReturn(Duration.ZERO);
         Set<StreamIdentifier> syncedStreams = scheduler.checkAndSyncStreamShardsAndLeases();
         Set<StreamIdentifier> expectedSyncedStreams = IntStream.concat(IntStream.range(1, 3), IntStream.range(5, 7))
                 .mapToObj(streamId -> StreamIdentifier.multiStreamInstance(

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.atMost;
+import static software.amazon.kinesis.processor.FormerStreamsLeasesDeletionStrategy.*;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -93,6 +94,7 @@ import software.amazon.kinesis.lifecycle.events.ShutdownRequestedInput;
 import software.amazon.kinesis.metrics.MetricsFactory;
 import software.amazon.kinesis.metrics.MetricsConfig;
 import software.amazon.kinesis.processor.Checkpointer;
+import software.amazon.kinesis.processor.FormerStreamsLeasesDeletionStrategy;
 import software.amazon.kinesis.processor.MultiStreamTracker;
 import software.amazon.kinesis.processor.ProcessorConfig;
 import software.amazon.kinesis.processor.ShardRecordProcessorFactory;
@@ -177,7 +179,12 @@ public class SchedulerTest {
         }};
 
         when(multiStreamTracker.streamConfigList()).thenReturn(streamConfigList);
-        when(multiStreamTracker.waitPeriodToDeleteOldStreams()).thenReturn(Duration.ofHours(1L));
+        when(multiStreamTracker.formerStreamsLeasesDeletionStrategy())
+                .thenReturn(new AutoDetectionAndDeferredDeletionStrategy() {
+                    @Override public Duration waitPeriodToDeleteFormerStreams() {
+                        return Duration.ZERO;
+                    }
+                });
         when(leaseCoordinator.leaseRefresher()).thenReturn(dynamoDBLeaseRefresher);
         when(shardSyncTaskManager.shardDetector()).thenReturn(shardDetector);
         when(retrievalFactory.createGetRecordsCache(any(ShardInfo.class), any(MetricsFactory.class))).thenReturn(recordsPublisher);
@@ -435,7 +442,56 @@ public class SchedulerTest {
     }
 
     @Test
-    public final void testMultiStreamStaleStreamsAreNotDeletedImmediately()
+    public final void testMultiStreamStaleStreamsAreNotDeletedImmediatelyAutoDeletionStrategy()
+            throws DependencyException, ProvisionedThroughputException, InvalidStateException {
+        when(multiStreamTracker.formerStreamsLeasesDeletionStrategy()).thenReturn(new AutoDetectionAndDeferredDeletionStrategy() {
+            @Override public Duration waitPeriodToDeleteFormerStreams() {
+                return Duration.ofHours(1);
+            }
+        });
+        testMultiStreamStaleStreamsAreNotDeletedImmediately(true);
+    }
+
+    @Test
+    public final void testMultiStreamStaleStreamsAreNotDeletedImmediatelyNoDeletionStrategy()
+            throws DependencyException, ProvisionedThroughputException, InvalidStateException {
+        when(multiStreamTracker.formerStreamsLeasesDeletionStrategy()).thenReturn(new NoLeaseDeletionStrategy());
+        testMultiStreamStaleStreamsAreNotDeletedImmediately(false);
+    }
+
+    @Test
+    public final void testMultiStreamStaleStreamsAreNotDeletedImmediatelyProvidedListStrategy()
+            throws DependencyException, ProvisionedThroughputException, InvalidStateException {
+        when(multiStreamTracker.formerStreamsLeasesDeletionStrategy()).thenReturn(new ProvidedStreamsDeferredDeletionStrategy() {
+            @Override public List<StreamIdentifier> streamIdentifiers() {
+                return null;
+            }
+
+            @Override public Duration waitPeriodToDeleteFormerStreams() {
+                return Duration.ofHours(1);
+            }
+        });
+        testMultiStreamStaleStreamsAreNotDeletedImmediately(false);
+    }
+
+    @Test
+    public final void testMultiStreamStaleStreamsAreNotDeletedImmediatelyProvidedListStrategy2()
+            throws DependencyException, ProvisionedThroughputException, InvalidStateException {
+        when(multiStreamTracker.formerStreamsLeasesDeletionStrategy()).thenReturn(new ProvidedStreamsDeferredDeletionStrategy() {
+            @Override public List<StreamIdentifier> streamIdentifiers() {
+                return IntStream.range(1, 3).mapToObj(streamId -> StreamIdentifier.multiStreamInstance(
+                        Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345))).collect(
+                        Collectors.toCollection(ArrayList::new));
+            }
+
+            @Override public Duration waitPeriodToDeleteFormerStreams() {
+                return Duration.ofHours(1);
+            }
+        });
+        testMultiStreamStaleStreamsAreNotDeletedImmediately(true);
+    }
+
+    private final void testMultiStreamStaleStreamsAreNotDeletedImmediately(boolean expectPendingStreamsForDeletion)
             throws DependencyException, ProvisionedThroughputException, InvalidStateException {
         List<StreamConfig> streamConfigList1 = IntStream.range(1, 5).mapToObj(streamId -> new StreamConfig(
                 StreamIdentifier.multiStreamInstance(
@@ -450,6 +506,7 @@ public class SchedulerTest {
         retrievalConfig = new RetrievalConfig(kinesisClient, multiStreamTracker, applicationName)
                 .retrievalFactory(retrievalFactory);
         when(multiStreamTracker.streamConfigList()).thenReturn(streamConfigList1, streamConfigList2);
+
         scheduler = spy(new Scheduler(checkpointConfig, coordinatorConfig, leaseManagementConfig, lifecycleConfig,
                 metricsConfig, processorConfig, retrievalConfig));
         when(scheduler.shouldSyncStreamsNow()).thenReturn(true);
@@ -460,12 +517,59 @@ public class SchedulerTest {
         Assert.assertEquals(Sets.newHashSet(), syncedStreams);
         Assert.assertEquals(Sets.newHashSet(streamConfigList1),
                 Sets.newHashSet(scheduler.currentStreamConfigMap().values()));
-        Assert.assertEquals(expectedPendingStreams,
+        Assert.assertEquals(expectPendingStreamsForDeletion ? expectedPendingStreams : Sets.newHashSet(),
                 scheduler.staleStreamDeletionMap().keySet());
     }
 
     @Test
-    public final void testMultiStreamStaleStreamsAreDeletedAfterDefermentPeriod()
+    public final void testMultiStreamStaleStreamsAreDeletedAfterDefermentPeriodWithAutoDetectionStrategy()
+            throws DependencyException, ProvisionedThroughputException, InvalidStateException {
+        when(multiStreamTracker.formerStreamsLeasesDeletionStrategy()).thenReturn(new AutoDetectionAndDeferredDeletionStrategy() {
+            @Override public Duration waitPeriodToDeleteFormerStreams() {
+                return Duration.ZERO;
+            }
+        });
+        testMultiStreamStaleStreamsAreDeletedAfterDefermentPeriod(true, null);
+    }
+
+    @Test
+    public final void testMultiStreamStaleStreamsAreDeletedAfterDefermentPeriodWithProvidedListStrategy()
+            throws DependencyException, ProvisionedThroughputException, InvalidStateException {
+        when(multiStreamTracker.formerStreamsLeasesDeletionStrategy()).thenReturn(new ProvidedStreamsDeferredDeletionStrategy() {
+            @Override public List<StreamIdentifier> streamIdentifiers() {
+                return null;
+            }
+
+            @Override public Duration waitPeriodToDeleteFormerStreams() {
+                return Duration.ZERO;
+            }
+        });
+        HashSet<StreamConfig> currentStreamConfigMapOverride = IntStream.range(1, 5).mapToObj(
+                streamId -> new StreamConfig(StreamIdentifier.multiStreamInstance(
+                        Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345)),
+                        InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST)))
+                .collect(Collectors.toCollection(HashSet::new));
+        testMultiStreamStaleStreamsAreDeletedAfterDefermentPeriod(false, currentStreamConfigMapOverride);
+    }
+
+    @Test
+    public final void testMultiStreamStaleStreamsAreDeletedAfterDefermentPeriodWithProvidedListStrategy2()
+            throws DependencyException, ProvisionedThroughputException, InvalidStateException {
+        when(multiStreamTracker.formerStreamsLeasesDeletionStrategy()).thenReturn(new ProvidedStreamsDeferredDeletionStrategy() {
+            @Override public List<StreamIdentifier> streamIdentifiers() {
+                return IntStream.range(1, 3).mapToObj(streamId -> StreamIdentifier.multiStreamInstance(
+                        Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345))).collect(
+                        Collectors.toCollection(ArrayList::new));
+            }
+
+            @Override public Duration waitPeriodToDeleteFormerStreams() {
+                return Duration.ZERO;
+            }
+        });
+        testMultiStreamStaleStreamsAreDeletedAfterDefermentPeriod(true, null);
+    }
+
+    private final void testMultiStreamStaleStreamsAreDeletedAfterDefermentPeriod(boolean expectSyncedStreams, Set<StreamConfig> currentStreamConfigMapOverride)
             throws DependencyException, ProvisionedThroughputException, InvalidStateException {
         List<StreamConfig> streamConfigList1 = IntStream.range(1, 5).mapToObj(streamId -> new StreamConfig(
                 StreamIdentifier.multiStreamInstance(
@@ -483,20 +587,69 @@ public class SchedulerTest {
         scheduler = spy(new Scheduler(checkpointConfig, coordinatorConfig, leaseManagementConfig, lifecycleConfig,
                 metricsConfig, processorConfig, retrievalConfig));
         when(scheduler.shouldSyncStreamsNow()).thenReturn(true);
-        when(multiStreamTracker.waitPeriodToDeleteOldStreams()).thenReturn(Duration.ZERO);
         Set<StreamIdentifier> syncedStreams = scheduler.checkAndSyncStreamShardsAndLeases();
         Set<StreamIdentifier> expectedSyncedStreams = IntStream.range(1, 3).mapToObj(streamId -> StreamIdentifier.multiStreamInstance(
                 Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345))).collect(
                 Collectors.toCollection(HashSet::new));
-        Assert.assertEquals(expectedSyncedStreams, syncedStreams);
-        Assert.assertEquals(Sets.newHashSet(streamConfigList2),
+        Assert.assertEquals(expectSyncedStreams ? expectedSyncedStreams : Sets.newHashSet(), syncedStreams);
+        Assert.assertEquals(currentStreamConfigMapOverride == null ? Sets.newHashSet(streamConfigList2) : currentStreamConfigMapOverride,
                 Sets.newHashSet(scheduler.currentStreamConfigMap().values()));
         Assert.assertEquals(Sets.newHashSet(),
                 scheduler.staleStreamDeletionMap().keySet());
     }
 
     @Test
-    public final void testMultiStreamNewStreamsAreSyncedAndStaleStreamsAreNotDeletedImmediately()
+    public final void testMultiStreamNewStreamsAreSyncedAndStaleStreamsAreNotDeletedImmediatelyWithAutoDetectionStrategy()
+            throws DependencyException, ProvisionedThroughputException, InvalidStateException {
+        when(multiStreamTracker.formerStreamsLeasesDeletionStrategy()).thenReturn(new AutoDetectionAndDeferredDeletionStrategy() {
+            @Override public Duration waitPeriodToDeleteFormerStreams() {
+                return Duration.ofHours(1);
+            }
+        });
+        testMultiStreamNewStreamsAreSyncedAndStaleStreamsAreNotDeletedImmediately(true);
+    }
+
+    @Test
+    public final void testMultiStreamNewStreamsAreSyncedAndStaleStreamsAreNotDeletedImmediatelyWithNoDeletionStrategy()
+            throws DependencyException, ProvisionedThroughputException, InvalidStateException {
+        when(multiStreamTracker.formerStreamsLeasesDeletionStrategy()).thenReturn(new NoLeaseDeletionStrategy());
+        testMultiStreamNewStreamsAreSyncedAndStaleStreamsAreNotDeletedImmediately(false);
+    }
+
+    @Test
+    public final void testMultiStreamNewStreamsAreSyncedAndStaleStreamsAreNotDeletedImmediatelyWithProvidedListStrategy()
+            throws DependencyException, ProvisionedThroughputException, InvalidStateException {
+        when(multiStreamTracker.formerStreamsLeasesDeletionStrategy()).thenReturn(new ProvidedStreamsDeferredDeletionStrategy() {
+            @Override public List<StreamIdentifier> streamIdentifiers() {
+                return null;
+            }
+
+            @Override public Duration waitPeriodToDeleteFormerStreams() {
+                return Duration.ofHours(1);
+            }
+        });
+        testMultiStreamNewStreamsAreSyncedAndStaleStreamsAreNotDeletedImmediately(false);
+    }
+
+    @Test
+    public final void testMultiStreamNewStreamsAreSyncedAndStaleStreamsAreNotDeletedImmediatelyWithProvidedListStrategy2()
+            throws DependencyException, ProvisionedThroughputException, InvalidStateException {
+        when(multiStreamTracker.formerStreamsLeasesDeletionStrategy()).thenReturn(new ProvidedStreamsDeferredDeletionStrategy() {
+            @Override public List<StreamIdentifier> streamIdentifiers() {
+                return IntStream.range(1, 3)
+                        .mapToObj(streamId -> StreamIdentifier.multiStreamInstance(
+                                Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345)))
+                        .collect(Collectors.toCollection(ArrayList::new));
+            }
+
+            @Override public Duration waitPeriodToDeleteFormerStreams() {
+                return Duration.ofHours(1);
+            }
+        });
+        testMultiStreamNewStreamsAreSyncedAndStaleStreamsAreNotDeletedImmediately(true);
+    }
+
+    private final void testMultiStreamNewStreamsAreSyncedAndStaleStreamsAreNotDeletedImmediately(boolean expectPendingStreamsForDeletion)
             throws DependencyException, ProvisionedThroughputException, InvalidStateException {
         List<StreamConfig> streamConfigList1 = IntStream.range(1, 5).mapToObj(streamId -> new StreamConfig(
                 StreamIdentifier.multiStreamInstance(
@@ -531,7 +684,7 @@ public class SchedulerTest {
                 .collect(Collectors.toCollection(LinkedList::new));
         Assert.assertEquals(Sets.newHashSet(expectedCurrentStreamConfigs),
                 Sets.newHashSet(scheduler.currentStreamConfigMap().values()));
-        Assert.assertEquals(expectedPendingStreams,
+        Assert.assertEquals(expectPendingStreamsForDeletion ? expectedPendingStreams: Sets.newHashSet(),
                 scheduler.staleStreamDeletionMap().keySet());
     }
 
@@ -554,7 +707,11 @@ public class SchedulerTest {
         scheduler = spy(new Scheduler(checkpointConfig, coordinatorConfig, leaseManagementConfig, lifecycleConfig,
                 metricsConfig, processorConfig, retrievalConfig));
         when(scheduler.shouldSyncStreamsNow()).thenReturn(true);
-        when(multiStreamTracker.waitPeriodToDeleteOldStreams()).thenReturn(Duration.ZERO);
+        when(multiStreamTracker.formerStreamsLeasesDeletionStrategy()).thenReturn(new AutoDetectionAndDeferredDeletionStrategy() {
+            @Override public Duration waitPeriodToDeleteFormerStreams() {
+                return Duration.ZERO;
+            }
+        });
         Set<StreamIdentifier> syncedStreams = scheduler.checkAndSyncStreamShardsAndLeases();
         Set<StreamIdentifier> expectedSyncedStreams = IntStream.concat(IntStream.range(1, 3), IntStream.range(5, 7))
                 .mapToObj(streamId -> StreamIdentifier.multiStreamInstance(

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/coordinator/SchedulerTest.java
@@ -36,6 +36,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.atMost;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -436,7 +437,7 @@ public class SchedulerTest {
     }
 
     @Test
-    public final void testMultiStreamOnlyStaleStreamsAreSynced()
+    public final void testMultiStreamStaleStreamsAreNotDeletedImmediately()
             throws DependencyException, ProvisionedThroughputException, InvalidStateException {
         List<StreamConfig> streamConfigList1 = IntStream.range(1, 5).mapToObj(streamId -> new StreamConfig(
                 StreamIdentifier.multiStreamInstance(
@@ -455,16 +456,49 @@ public class SchedulerTest {
                 metricsConfig, processorConfig, retrievalConfig));
         when(scheduler.shouldSyncStreamsNow()).thenReturn(true);
         Set<StreamIdentifier> syncedStreams = scheduler.checkAndSyncStreamShardsAndLeases();
+        Set<StreamIdentifier> expectedPendingStreams = IntStream.range(1, 3).mapToObj(streamId -> StreamIdentifier.multiStreamInstance(
+                Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345))).collect(
+                Collectors.toCollection(HashSet::new));
+        Assert.assertEquals(Sets.newHashSet(), syncedStreams);
+        Assert.assertEquals(Sets.newHashSet(streamConfigList1),
+                Sets.newHashSet(scheduler.currentStreamConfigMap().values()));
+        Assert.assertEquals(expectedPendingStreams,
+                scheduler.staleStreamDeletionMap().keySet());
+    }
+
+    @Test
+    public final void testMultiStreamStaleStreamsAreDeletedAfterDefermentPeriod()
+            throws DependencyException, ProvisionedThroughputException, InvalidStateException {
+        List<StreamConfig> streamConfigList1 = IntStream.range(1, 5).mapToObj(streamId -> new StreamConfig(
+                StreamIdentifier.multiStreamInstance(
+                        Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345)),
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST)))
+                .collect(Collectors.toCollection(LinkedList::new));
+        List<StreamConfig> streamConfigList2 = IntStream.range(3, 5).mapToObj(streamId -> new StreamConfig(
+                StreamIdentifier.multiStreamInstance(
+                        Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345)),
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST)))
+                .collect(Collectors.toCollection(LinkedList::new));
+        retrievalConfig = new RetrievalConfig(kinesisClient, multiStreamTracker, applicationName)
+                .retrievalFactory(retrievalFactory);
+        when(multiStreamTracker.streamConfigList()).thenReturn(streamConfigList1, streamConfigList2);
+        scheduler = spy(new Scheduler(checkpointConfig, coordinatorConfig, leaseManagementConfig, lifecycleConfig,
+                metricsConfig, processorConfig, retrievalConfig));
+        when(scheduler.shouldSyncStreamsNow()).thenReturn(true);
+        when(scheduler.getOldStreamDeferredDeletionPeriodMillis()).thenReturn(0L);
+        Set<StreamIdentifier> syncedStreams = scheduler.checkAndSyncStreamShardsAndLeases();
         Set<StreamIdentifier> expectedSyncedStreams = IntStream.range(1, 3).mapToObj(streamId -> StreamIdentifier.multiStreamInstance(
                 Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345))).collect(
                 Collectors.toCollection(HashSet::new));
         Assert.assertEquals(expectedSyncedStreams, syncedStreams);
         Assert.assertEquals(Sets.newHashSet(streamConfigList2),
                 Sets.newHashSet(scheduler.currentStreamConfigMap().values()));
+        Assert.assertEquals(Sets.newHashSet(),
+                scheduler.staleStreamDeletionMap().keySet());
     }
 
     @Test
-    public final void testMultiStreamSyncOnlyNewAndStaleStreamsAreSynced()
+    public final void testMultiStreamNewStreamsAreSyncedAndStaleStreamsAreNotDeletedImmediately()
             throws DependencyException, ProvisionedThroughputException, InvalidStateException {
         List<StreamConfig> streamConfigList1 = IntStream.range(1, 5).mapToObj(streamId -> new StreamConfig(
                 StreamIdentifier.multiStreamInstance(
@@ -483,6 +517,47 @@ public class SchedulerTest {
                 metricsConfig, processorConfig, retrievalConfig));
         when(scheduler.shouldSyncStreamsNow()).thenReturn(true);
         Set<StreamIdentifier> syncedStreams = scheduler.checkAndSyncStreamShardsAndLeases();
+        Set<StreamIdentifier> expectedSyncedStreams = IntStream.range(5, 7)
+                .mapToObj(streamId -> StreamIdentifier.multiStreamInstance(
+                        Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345)))
+                .collect(Collectors.toCollection(HashSet::new));
+        Set<StreamIdentifier> expectedPendingStreams = IntStream.range(1, 3)
+                .mapToObj(streamId -> StreamIdentifier.multiStreamInstance(
+                        Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345)))
+                .collect(Collectors.toCollection(HashSet::new));
+        Assert.assertEquals(expectedSyncedStreams, syncedStreams);
+        List<StreamConfig> expectedCurrentStreamConfigs = IntStream.range(1, 7).mapToObj(streamId -> new StreamConfig(
+                StreamIdentifier.multiStreamInstance(
+                        Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345)),
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST)))
+                .collect(Collectors.toCollection(LinkedList::new));
+        Assert.assertEquals(Sets.newHashSet(expectedCurrentStreamConfigs),
+                Sets.newHashSet(scheduler.currentStreamConfigMap().values()));
+        Assert.assertEquals(expectedPendingStreams,
+                scheduler.staleStreamDeletionMap().keySet());
+    }
+
+    @Test
+    public final void testMultiStreamNewStreamsAreSyncedAndStaleStreamsAreDeletedAfterDefermentPeriod()
+            throws DependencyException, ProvisionedThroughputException, InvalidStateException {
+        List<StreamConfig> streamConfigList1 = IntStream.range(1, 5).mapToObj(streamId -> new StreamConfig(
+                StreamIdentifier.multiStreamInstance(
+                        Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345)),
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST)))
+                .collect(Collectors.toCollection(LinkedList::new));
+        List<StreamConfig> streamConfigList2 = IntStream.range(3, 7).mapToObj(streamId -> new StreamConfig(
+                StreamIdentifier.multiStreamInstance(
+                        Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345)),
+                InitialPositionInStreamExtended.newInitialPosition(InitialPositionInStream.LATEST)))
+                .collect(Collectors.toCollection(LinkedList::new));
+        retrievalConfig = new RetrievalConfig(kinesisClient, multiStreamTracker, applicationName)
+                .retrievalFactory(retrievalFactory);
+        when(multiStreamTracker.streamConfigList()).thenReturn(streamConfigList1, streamConfigList2);
+        scheduler = spy(new Scheduler(checkpointConfig, coordinatorConfig, leaseManagementConfig, lifecycleConfig,
+                metricsConfig, processorConfig, retrievalConfig));
+        when(scheduler.shouldSyncStreamsNow()).thenReturn(true);
+        when(scheduler.getOldStreamDeferredDeletionPeriodMillis()).thenReturn(0L);
+        Set<StreamIdentifier> syncedStreams = scheduler.checkAndSyncStreamShardsAndLeases();
         Set<StreamIdentifier> expectedSyncedStreams = IntStream.concat(IntStream.range(1, 3), IntStream.range(5, 7))
                 .mapToObj(streamId -> StreamIdentifier.multiStreamInstance(
                         Joiner.on(":").join(streamId * 111111111, "multiStreamTest-" + streamId, streamId * 12345)))
@@ -490,6 +565,8 @@ public class SchedulerTest {
         Assert.assertEquals(expectedSyncedStreams, syncedStreams);
         Assert.assertEquals(Sets.newHashSet(streamConfigList2),
                 Sets.newHashSet(scheduler.currentStreamConfigMap().values()));
+        Assert.assertEquals(Sets.newHashSet(),
+                scheduler.staleStreamDeletionMap().keySet());
     }
 
     @Test


### PR DESCRIPTION
Changes for adding stream as dimension in multistream mode. Changes for deferred cleanup of stale stream leases to free up record processors.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
