### PR TITLE
[Cherry-pick to ltr_1] Add DataFetcher and ShardDetector interface changes (#9)

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/KinesisShardDetector.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/leases/KinesisShardDetector.java
@@ -26,15 +26,13 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.StringUtils;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Synchronized;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.awssdk.services.kinesis.model.KinesisException;
 import software.amazon.awssdk.services.kinesis.model.LimitExceededException;

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownTask.java
@@ -16,6 +16,8 @@ package software.amazon.kinesis.lifecycle;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import java.util.List;
+import java.util.function.Function;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,11 +28,11 @@ import software.amazon.awssdk.utils.CollectionUtils;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.checkpoint.ShardRecordProcessorCheckpointer;
 import software.amazon.kinesis.common.InitialPositionInStreamExtended;
+import software.amazon.kinesis.leases.HierarchicalShardSyncer;
 import software.amazon.kinesis.leases.Lease;
 import software.amazon.kinesis.leases.LeaseCoordinator;
 import software.amazon.kinesis.leases.ShardDetector;
 import software.amazon.kinesis.leases.ShardInfo;
-import software.amazon.kinesis.leases.HierarchicalShardSyncer;
 import software.amazon.kinesis.leases.exceptions.CustomerApplicationException;
 import software.amazon.kinesis.leases.exceptions.DependencyException;
 import software.amazon.kinesis.leases.exceptions.InvalidStateException;
@@ -38,16 +40,12 @@ import software.amazon.kinesis.leases.exceptions.ProvisionedThroughputException;
 import software.amazon.kinesis.lifecycle.events.LeaseLostInput;
 import software.amazon.kinesis.lifecycle.events.ShardEndedInput;
 import software.amazon.kinesis.metrics.MetricsFactory;
-import software.amazon.kinesis.metrics.MetricsScope;
 import software.amazon.kinesis.metrics.MetricsLevel;
+import software.amazon.kinesis.metrics.MetricsScope;
 import software.amazon.kinesis.metrics.MetricsUtil;
 import software.amazon.kinesis.processor.ShardRecordProcessor;
 import software.amazon.kinesis.retrieval.RecordsPublisher;
 import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
-
-import java.util.List;
-import java.util.function.Function;
-
 /**
  * Task for invoking the ShardRecordProcessor shutdown() callback.
  */

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/events/ProcessRecordsInput.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/events/ProcessRecordsInput.java
@@ -57,6 +57,7 @@ public class ProcessRecordsInput {
      * The records received from Kinesis. These records may have been de-aggregated if they were published by the KPL.
      */
     private List<KinesisClientRecord> records;
+
     /**
      * A checkpointer that the {@link ShardRecordProcessor} can use to checkpoint its progress.
      */

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/DataFetcherProviderConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/DataFetcherProviderConfig.java
@@ -13,24 +13,36 @@
  * limitations under the License.
  */
 
-package software.amazon.kinesis.leases;
+package software.amazon.kinesis.retrieval;
 
-import java.util.List;
-import software.amazon.awssdk.services.kinesis.model.Shard;
-import software.amazon.awssdk.services.kinesis.model.ShardFilter;
+import java.time.Duration;
 import software.amazon.kinesis.common.StreamIdentifier;
+import software.amazon.kinesis.metrics.MetricsFactory;
 
-/**
- *
- */
-public interface ShardDetector {
-    Shard shard(String shardId);
+public interface DataFetcherProviderConfig {
 
-    List<Shard> listShards();
+    /**
+    * Gets stream identifier for dataFetcher.
+    */
+    StreamIdentifier getStreamIdentifier();
 
-    List<Shard> listShardsWithFilter(ShardFilter shardFilter);
+    /**
+    * Gets shard id.
+    */
+    String getShardId();
 
-    default StreamIdentifier streamIdentifier() {
-        throw new UnsupportedOperationException("StreamName not available");
-    }
+    /**
+     * Gets current instance of metrics factory.
+     */
+    MetricsFactory getMetricsFactory();
+
+    /**
+     * Gets current max records allowed to process at a given time.
+     */
+    Integer getMaxRecords();
+
+    /**
+     * Gets timeout for kinesis request.
+     */
+    Duration getKinesisRequestTimeout();
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/GetRecordsRetrievalStrategy.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/GetRecordsRetrievalStrategy.java
@@ -14,7 +14,9 @@
  */
 package software.amazon.kinesis.retrieval;
 
+import java.util.Optional;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.kinesis.retrieval.polling.DataFetcher;
 import software.amazon.kinesis.retrieval.polling.KinesisDataFetcher;
 
 /**
@@ -41,15 +43,33 @@ public interface GetRecordsRetrievalStrategy {
 
     /**
      * Returns whether this strategy has been shutdown.
-     * 
+     *
      * @return true if the strategy has been shutdown, false otherwise.
      */
     boolean isShutdown();
 
     /**
-     * Returns the KinesisDataFetcher used to records from Kinesis.
-     * 
-     * @return KinesisDataFetcher
+     * Returns a DataFetcher used to records from Kinesis.
+     *
+     * @return DataFetcher
      */
     KinesisDataFetcher getDataFetcher();
+
+    /**
+     * Returns a DataFetcher override if applicable, else empty for retrieving records from Kinesis.
+     *
+     * @return Optional<DataFetcher>
+     */
+    default Optional<DataFetcher> getDataFetcherOverride() {
+        return Optional.empty();
+    }
+
+    /**
+     * Returns a dataFetcher by first checking for an override if it exists, else using the default data fetcher.
+     *
+     * @return DataFetcher
+     */
+    default DataFetcher dataFetcher() {
+        return getDataFetcherOverride().orElse(getDataFetcher());
+    }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/KinesisDataFetcherProviderConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/KinesisDataFetcherProviderConfig.java
@@ -13,24 +13,33 @@
  * limitations under the License.
  */
 
-package software.amazon.kinesis.leases;
+package software.amazon.kinesis.retrieval;
 
-import java.util.List;
-import software.amazon.awssdk.services.kinesis.model.Shard;
-import software.amazon.awssdk.services.kinesis.model.ShardFilter;
+import java.time.Duration;
+import lombok.Data;
+import lombok.NonNull;
 import software.amazon.kinesis.common.StreamIdentifier;
+import software.amazon.kinesis.metrics.MetricsFactory;
+
 
 /**
- *
+ * Configuration needed for custom data fetchers
  */
-public interface ShardDetector {
-    Shard shard(String shardId);
+@Data
+public class KinesisDataFetcherProviderConfig implements DataFetcherProviderConfig {
 
-    List<Shard> listShards();
+    @NonNull
+    private StreamIdentifier streamIdentifier;
 
-    List<Shard> listShardsWithFilter(ShardFilter shardFilter);
+    @NonNull
+    private String shardId;
 
-    default StreamIdentifier streamIdentifier() {
-        throw new UnsupportedOperationException("StreamName not available");
-    }
+    @NonNull
+    private MetricsFactory metricsFactory;
+
+    @NonNull
+    private Integer maxRecords;
+
+    @NonNull
+    private Duration kinesisRequestTimeout;
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalSpecificConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/RetrievalSpecificConfig.java
@@ -15,10 +15,13 @@
 
 package software.amazon.kinesis.retrieval;
 
+import java.util.function.Function;
+import software.amazon.kinesis.retrieval.polling.DataFetcher;
+
 public interface RetrievalSpecificConfig {
     /**
      * Creates and returns a retrieval factory for the specific configuration
-     * 
+     *
      * @return a retrieval factory that can create an appropriate retriever
      */
     RetrievalFactory retrievalFactory();

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/DataFetcher.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/DataFetcher.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package software.amazon.kinesis.retrieval.polling;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import lombok.NonNull;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.kinesis.common.InitialPositionInStreamExtended;
+import software.amazon.kinesis.common.StreamIdentifier;
+import software.amazon.kinesis.retrieval.DataFetcherResult;
+import software.amazon.kinesis.retrieval.kpl.ExtendedSequenceNumber;
+
+public interface DataFetcher {
+    /**
+     * Get records from the current position in the stream (up to maxRecords).
+     *
+     * @return list of records of up to maxRecords size
+     */
+    DataFetcherResult getRecords();
+
+    /**
+     * Initializes this KinesisDataFetcher's iterator based on the checkpointed sequence number.
+     *
+     * @param initialCheckpoint       Current checkpoint sequence number for this shard.
+     * @param initialPositionInStream The initialPositionInStream.
+     */
+    void initialize(String initialCheckpoint,
+                    InitialPositionInStreamExtended initialPositionInStream);
+
+    /**
+     * Initializes this KinesisDataFetcher's iterator based on the checkpointed sequence number as an
+     * ExtendedSequenceNumber.
+     *
+     * @param initialCheckpoint       Current checkpoint sequence number for this shard.
+     * @param initialPositionInStream The initialPositionInStream.
+     */
+    void initialize(ExtendedSequenceNumber initialCheckpoint,
+                    InitialPositionInStreamExtended initialPositionInStream);
+
+    /**
+     * Advances this KinesisDataFetcher's internal iterator to be at the passed-in sequence number.
+     *
+     * @param sequenceNumber          advance the iterator to the record at this sequence number.
+     * @param initialPositionInStream The initialPositionInStream.
+     */
+    void advanceIteratorTo(String sequenceNumber,
+                           InitialPositionInStreamExtended initialPositionInStream);
+
+    /**
+     * Gets a new iterator from the last known sequence number i.e. the sequence number of the last record from the last
+     * records call.
+     */
+    void restartIterator();
+
+    /**
+     * Resets the iterator by setting shardIterator, sequenceNumber and the position in the stream.
+     *
+     * @param shardIterator           set the current shard iterator.
+     * @param sequenceNumber          reset the iterator to the record at this sequence number.
+     * @param initialPositionInStream the current position in the stream to reset the iterator to.
+     */
+    void resetIterator(String shardIterator, String sequenceNumber, InitialPositionInStreamExtended initialPositionInStream);
+
+    /**
+     * Retrieves the response based on the request.
+     *
+     * @param request the current get records request used to receive a response.
+     * @return GetRecordsResponse response for getRecords
+     */
+    GetRecordsResponse getGetRecordsResponse(GetRecordsRequest request) throws Exception;
+
+    /**
+     * Retrieves the next get records request based on the current iterator.
+     *
+     * @param nextIterator specify the iterator to get the next record request
+     * @return {@link GetRecordsRequest}
+     */
+    GetRecordsRequest getGetRecordsRequest(String nextIterator);
+
+    /**
+     * Gets the next iterator based on the request.
+     *
+     * @param request used to obtain the next shard iterator
+     * @return next iterator string
+     */
+    String getNextIterator(GetShardIteratorRequest request) throws ExecutionException, InterruptedException, TimeoutException;
+
+    /**
+     * Gets the next set of records based on the iterator.
+     *
+     * @param nextIterator specified shard iterator for getting the next set of records
+     * @return {@link GetRecordsResponse}
+     */
+    GetRecordsResponse getRecords(@NonNull String nextIterator);
+
+    /**
+     * Get the current account and stream information.
+     *
+     * @return {@link StreamIdentifier}
+     */
+    StreamIdentifier getStreamIdentifier();
+
+    /**
+     * Checks if shardEnd is reached.
+     * @return boolean to determine whether shard end is reached
+     */
+    boolean isShardEndReached();
+}

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/PollingConfig.java
@@ -17,31 +17,47 @@ package software.amazon.kinesis.retrieval.polling;
 
 import java.time.Duration;
 import java.util.Optional;
-
+import java.util.function.Function;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
+import lombok.ToString;
 import lombok.experimental.Accessors;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.kinesis.retrieval.DataFetcherProviderConfig;
 import software.amazon.kinesis.retrieval.RecordsFetcherFactory;
 import software.amazon.kinesis.retrieval.RetrievalFactory;
 import software.amazon.kinesis.retrieval.RetrievalSpecificConfig;
 
 @Accessors(fluent = true)
-@Data
 @Getter
+@Setter
+@ToString
+@EqualsAndHashCode
 public class PollingConfig implements RetrievalSpecificConfig {
 
     public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(30);
 
     /**
+     * Configurable functional interface to override the existing DataFetcher.
+     */
+    Function<DataFetcherProviderConfig, DataFetcher> dataFetcherProvider;
+    /**
      * Name of the Kinesis stream.
      *
      * @return String
      */
-    @NonNull
-    private final String streamName;
+    private String streamName;
+
+    /**
+     * @param kinesisClient Client used to access Kinesis services.
+     */
+    public PollingConfig(KinesisAsyncClient kinesisClient) {
+        this.kinesisClient = kinesisClient;
+    }
 
     /**
      * Client used to access to Kinesis service.
@@ -59,6 +75,15 @@ public class PollingConfig implements RetrievalSpecificConfig {
      * </p>
      */
     private int maxRecords = 10000;
+
+    /**
+     * @param streamName    Name of Kinesis stream.
+     * @param kinesisClient Client used to access Kinesis serivces.
+     */
+    public PollingConfig(String streamName, KinesisAsyncClient kinesisClient) {
+        this.kinesisClient = kinesisClient;
+        this.streamName = streamName;
+    }
 
     /**
      * The value for how long the ShardConsumer should sleep if no records are returned from the call to
@@ -105,6 +130,6 @@ public class PollingConfig implements RetrievalSpecificConfig {
     @Override
     public RetrievalFactory retrievalFactory() {
         return new SynchronousBlockingRetrievalFactory(streamName(), kinesisClient(), recordsFetcherFactory,
-                maxRecords(), kinesisRequestTimeout);
+                maxRecords(), kinesisRequestTimeout, dataFetcherProvider);
     }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SynchronousBlockingRetrievalFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SynchronousBlockingRetrievalFactory.java
@@ -15,6 +15,8 @@
 
 package software.amazon.kinesis.retrieval.polling;
 
+import java.time.Duration;
+import java.util.function.Function;
 import lombok.Data;
 import lombok.NonNull;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
@@ -22,12 +24,12 @@ import software.amazon.kinesis.annotations.KinesisClientInternalApi;
 import software.amazon.kinesis.common.StreamIdentifier;
 import software.amazon.kinesis.leases.ShardInfo;
 import software.amazon.kinesis.metrics.MetricsFactory;
+import software.amazon.kinesis.retrieval.DataFetcherProviderConfig;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
+import software.amazon.kinesis.retrieval.KinesisDataFetcherProviderConfig;
 import software.amazon.kinesis.retrieval.RecordsFetcherFactory;
 import software.amazon.kinesis.retrieval.RecordsPublisher;
 import software.amazon.kinesis.retrieval.RetrievalFactory;
-
-import java.time.Duration;
 
 /**
  *
@@ -42,32 +44,71 @@ public class SynchronousBlockingRetrievalFactory implements RetrievalFactory {
     private final KinesisAsyncClient kinesisClient;
     @NonNull
     private final RecordsFetcherFactory recordsFetcherFactory;
-    // private final long listShardsBackoffTimeInMillis;
-    // private final int maxListShardsRetryAttempts;
+
     private final int maxRecords;
     private final Duration kinesisRequestTimeout;
 
-    public SynchronousBlockingRetrievalFactory(String streamName, KinesisAsyncClient kinesisClient, RecordsFetcherFactory recordsFetcherFactory, int maxRecords, Duration kinesisRequestTimeout) {
+    private final Function<DataFetcherProviderConfig, DataFetcher> dataFetcherProvider;
+
+    @Deprecated
+    public SynchronousBlockingRetrievalFactory(String streamName,
+                                               KinesisAsyncClient kinesisClient,
+                                               RecordsFetcherFactory recordsFetcherFactory,
+                                               int maxRecords,
+                                               Duration kinesisRequestTimeout) {
+        this(streamName,
+                kinesisClient,
+                recordsFetcherFactory,
+                maxRecords,
+                kinesisRequestTimeout,
+                defaultDataFetcherProvider(kinesisClient));
+    }
+
+    public SynchronousBlockingRetrievalFactory(String streamName,
+                                               KinesisAsyncClient kinesisClient,
+                                               RecordsFetcherFactory recordsFetcherFactory,
+                                               int maxRecords,
+                                               Duration kinesisRequestTimeout,
+                                               Function<DataFetcherProviderConfig, DataFetcher> dataFetcherProvider) {
         this.streamName = streamName;
         this.kinesisClient = kinesisClient;
         this.recordsFetcherFactory = recordsFetcherFactory;
         this.maxRecords = maxRecords;
         this.kinesisRequestTimeout = kinesisRequestTimeout;
+        this.dataFetcherProvider = dataFetcherProvider == null ?
+                defaultDataFetcherProvider(kinesisClient) : dataFetcherProvider;
     }
 
     @Deprecated
-    public SynchronousBlockingRetrievalFactory(String streamName, KinesisAsyncClient kinesisClient, RecordsFetcherFactory recordsFetcherFactory, int maxRecords) {
+    public SynchronousBlockingRetrievalFactory(String streamName,
+                                               KinesisAsyncClient kinesisClient,
+                                               RecordsFetcherFactory recordsFetcherFactory,
+                                               int maxRecords) {
         this(streamName, kinesisClient, recordsFetcherFactory, maxRecords, PollingConfig.DEFAULT_REQUEST_TIMEOUT);
+    }
+
+    private static Function<DataFetcherProviderConfig, DataFetcher> defaultDataFetcherProvider(
+            KinesisAsyncClient kinesisClient) {
+        return dataFetcherProviderConfig -> new KinesisDataFetcher(kinesisClient, dataFetcherProviderConfig);
     }
 
     @Override
     public GetRecordsRetrievalStrategy createGetRecordsRetrievalStrategy(@NonNull final ShardInfo shardInfo,
-            @NonNull final MetricsFactory metricsFactory) {
+                                                                         @NonNull final MetricsFactory metricsFactory) {
         final StreamIdentifier streamIdentifier = shardInfo.streamIdentifierSerOpt().isPresent() ?
                 StreamIdentifier.multiStreamInstance(shardInfo.streamIdentifierSerOpt().get()) :
                 StreamIdentifier.singleStreamInstance(streamName);
-        return new SynchronousGetRecordsRetrievalStrategy(
-                new KinesisDataFetcher(kinesisClient, streamIdentifier, shardInfo.shardId(), maxRecords, metricsFactory, kinesisRequestTimeout));
+
+        final DataFetcherProviderConfig kinesisDataFetcherProviderConfig = new KinesisDataFetcherProviderConfig(
+                streamIdentifier,
+                shardInfo.shardId(),
+                metricsFactory,
+                maxRecords,
+                kinesisRequestTimeout);
+
+        final DataFetcher dataFetcher = this.dataFetcherProvider.apply(kinesisDataFetcherProviderConfig);
+
+        return new SynchronousGetRecordsRetrievalStrategy(dataFetcher);
     }
 
     @Override

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SynchronousGetRecordsRetrievalStrategy.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SynchronousGetRecordsRetrievalStrategy.java
@@ -14,6 +14,7 @@
  */
 package software.amazon.kinesis.retrieval.polling;
 
+import java.util.Optional;
 import lombok.Data;
 import lombok.NonNull;
 import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
@@ -26,8 +27,9 @@ import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
 @Data
 @KinesisClientInternalApi
 public class SynchronousGetRecordsRetrievalStrategy implements GetRecordsRetrievalStrategy {
+
     @NonNull
-    private final KinesisDataFetcher dataFetcher;
+    private final DataFetcher dataFetcher;
 
     @Override
     public GetRecordsResponse getRecords(final int maxRecords) {
@@ -45,9 +47,14 @@ public class SynchronousGetRecordsRetrievalStrategy implements GetRecordsRetriev
     public boolean isShutdown() {
         return false;
     }
-    
+
     @Override
     public KinesisDataFetcher getDataFetcher() {
+        throw new UnsupportedOperationException("Deprecated. Use dataFetcher() to retrieve a dataFetcher");
+    }
+
+    @Override
+    public DataFetcher dataFetcher() {
         return dataFetcher;
     }
 }

--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SynchronousPrefetchingRetrievalFactory.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/retrieval/polling/SynchronousPrefetchingRetrievalFactory.java
@@ -17,7 +17,6 @@ package software.amazon.kinesis.retrieval.polling;
 
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
-
 import lombok.NonNull;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.kinesis.annotations.KinesisClientInternalApi;
@@ -25,6 +24,7 @@ import software.amazon.kinesis.common.StreamIdentifier;
 import software.amazon.kinesis.leases.ShardInfo;
 import software.amazon.kinesis.metrics.MetricsFactory;
 import software.amazon.kinesis.retrieval.GetRecordsRetrievalStrategy;
+import software.amazon.kinesis.retrieval.KinesisDataFetcherProviderConfig;
 import software.amazon.kinesis.retrieval.RecordsFetcherFactory;
 import software.amazon.kinesis.retrieval.RecordsPublisher;
 import software.amazon.kinesis.retrieval.RetrievalFactory;
@@ -71,9 +71,15 @@ public class SynchronousPrefetchingRetrievalFactory implements RetrievalFactory 
         final StreamIdentifier streamIdentifier = shardInfo.streamIdentifierSerOpt().isPresent() ?
                 StreamIdentifier.multiStreamInstance(shardInfo.streamIdentifierSerOpt().get()) :
                 StreamIdentifier.singleStreamInstance(streamName);
+
         return new SynchronousGetRecordsRetrievalStrategy(
-                new KinesisDataFetcher(kinesisClient, streamIdentifier, shardInfo.shardId(),
-                        maxRecords, metricsFactory, maxFutureWait));
+                new KinesisDataFetcher(kinesisClient, new KinesisDataFetcherProviderConfig(
+                        streamIdentifier,
+                        shardInfo.shardId(),
+                        metricsFactory,
+                        maxRecords,
+                        maxFutureWait
+                )));
     }
 
     @Override

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/PrefetchRecordsPublisherTest.java
@@ -107,7 +107,7 @@ public class PrefetchRecordsPublisherTest {
     @Mock
     private GetRecordsRetrievalStrategy getRecordsRetrievalStrategy;
     @Mock
-    private KinesisDataFetcher dataFetcher;
+    private DataFetcher dataFetcher;
     @Mock
     private InitialPositionInStreamExtended initialPosition;
     @Mock
@@ -124,7 +124,7 @@ public class PrefetchRecordsPublisherTest {
 
     @Before
     public void setup() {
-        when(getRecordsRetrievalStrategy.getDataFetcher()).thenReturn(dataFetcher);
+        when(getRecordsRetrievalStrategy.dataFetcher()).thenReturn(dataFetcher);
         when(dataFetcher.getStreamIdentifier()).thenReturn(StreamIdentifier.singleStreamInstance("testStream"));
         executorService = spy(Executors.newFixedThreadPool(1));
         getRecordsCache = new PrefetchRecordsPublisher(

--- a/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/RecordsFetcherFactoryTest.java
+++ b/amazon-kinesis-client/src/test/java/software/amazon/kinesis/retrieval/polling/RecordsFetcherFactoryTest.java
@@ -40,14 +40,14 @@ public class RecordsFetcherFactoryTest {
     @Mock
     private MetricsFactory metricsFactory;
     @Mock
-    private KinesisDataFetcher kinesisDataFetcher;
+    private DataFetcher dataFetcher;
 
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         recordsFetcherFactory = new SimpleRecordsFetcherFactory();
-        when(getRecordsRetrievalStrategy.getDataFetcher()).thenReturn(kinesisDataFetcher);
-        when(kinesisDataFetcher.getStreamIdentifier()).thenReturn(StreamIdentifier.singleStreamInstance("stream"));
+        when(getRecordsRetrievalStrategy.dataFetcher()).thenReturn(dataFetcher);
+        when(dataFetcher.getStreamIdentifier()).thenReturn(StreamIdentifier.singleStreamInstance("stream"));
     }
 
     @Test
@@ -66,5 +66,4 @@ public class RecordsFetcherFactoryTest {
                 metricsFactory, 1);
         assertThat(recordsCache, instanceOf(PrefetchRecordsPublisher.class));
     }
-
 }


### PR DESCRIPTION
* Add DataFetcher and ShardDetector interface changes

* Allow passing in custom shard detector and custom data fetcher through configs

* update javadoc comment

* Add extra type check for KinesisShardDetector

* Update javadoc

* update prefetchRecordsPublisher

* ShardDetector now passed created in DynamoDBLeaseManagementFactory
DataFetcher interface updated
Updated Functional interface for ShardDetector and DataFetcher

* update var names

* Added DataFetcherProviderConfig to make functional interface arugments clear

* Deprecate getDataFetcher method

* Add additional vars for DataFetcherProviderConfig

* Add missing doc strings & use interface for Config impl

* Fix test

* tests & readability

* Remove constructor args from DDBLeaseManagementFactory
Code clean up
Update RetrievalConfig

* deprecate method, remove extra constructor

* Move dataFetcher to PollingConfig, add validation

* remove override method

* remove unused annotation + update exception type

* make lombok annotations explicit

* remove commented code

* Clean up SynchronousBlockingRetrievalFactory

* use custom shard detector

* update doc strings

Co-authored-by: Renju Radhakrishnan <rrenju@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
