### PR TITLE
Add leader-elected shard sync on application bootstrap

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
@@ -177,7 +177,7 @@ class KinesisShardSyncer implements ShardSyncer {
 
         List<Shard> shards;
         if(CollectionUtils.isNullOrEmpty(latestShards)) {
-            shards = getCompleteShardList(kinesisProxy);
+            shards = getShardListAtInitialPosition(kinesisProxy, initialPosition);
         } else {
             shards = latestShards;
         }
@@ -602,6 +602,7 @@ class KinesisShardSyncer implements ShardSyncer {
         if (!garbageLeases.isEmpty()) {
             LOG.info("Found " + garbageLeases.size() + " candidate leases for cleanup. Refreshing list of"
                     + " Kinesis shards to pick up recent/latest shards");
+            // TODO: Update to ListShardsWithFilter once lease GC is finalized
             List<Shard> currentShardList = getCompleteShardList(kinesisProxy);
             Set<String> currentKinesisShardIds = new HashSet<>();
             for (Shard shard : currentShardList) {

--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardEndShardSyncStrategy.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardEndShardSyncStrategy.java
@@ -42,6 +42,7 @@ class ShardEndShardSyncStrategy implements ShardSyncStrategy {
 
     @Override
     public TaskResult onWorkerInitialization() {
+        // TODO: Start leaderElectedPeriodicShardSyncManager in background
         LOG.debug(String.format("onWorkerInitialization is NoOp for ShardSyncStrategyType %s", getStrategyType().toString()));
         return new TaskResult(null);
     }
@@ -65,6 +66,7 @@ class ShardEndShardSyncStrategy implements ShardSyncStrategy {
 
     @Override
     public void onWorkerShutDown() {
+        // TODO: Shut down leaderElectedPeriodicShardSyncManager
         LOG.debug(String.format("Stop is NoOp for ShardSyncStrategyType %s", getStrategyType().toString()));
     }
 }

--- a/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncerTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/ShardSyncerTest.java
@@ -18,7 +18,6 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,7 +29,6 @@ import java.util.stream.Stream;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.local.embedded.DynamoDBEmbedded;
-import com.amazonaws.services.kinesis.leases.impl.Lease;
 import com.amazonaws.services.kinesis.model.ShardFilter;
 import com.amazonaws.services.kinesis.model.ShardFilterType;
 import org.apache.commons.logging.Log;
@@ -60,7 +58,7 @@ import com.amazonaws.services.kinesis.model.Shard;
 
 import junit.framework.Assert;
 
-import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -1816,10 +1814,13 @@ public class ShardSyncerTest {
         dataFile.deleteOnExit();
         final IKinesisProxy kinesisProxy = spy(new KinesisLocalFileProxy(dataFile.getAbsolutePath()));
 
+        // Make sure ListShardsWithFilter is called in all public shard sync methods
         shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, initialPosition,
                 cleanupLeasesOfCompletedShards, false);
+        shardSyncer.checkAndCreateLeasesForNewShards(kinesisProxy, leaseManager, initialPosition,
+                cleanupLeasesOfCompletedShards, false, null);
 
-        verify(kinesisProxy, atLeastOnce()).getShardListWithFilter(shardFilter);
+        verify(kinesisProxy, atLeast(2)).getShardListWithFilter(shardFilter);
         verify(kinesisProxy, never()).getShardList();
     }
 


### PR DESCRIPTION
Initial commit for leader elected shard sync on application bootstrap for KCL 1.x. Still need to add unit tests for new functionality and implement periodic shard sync for ShardEndShardSync strategy. Existing unit tests pass.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
