### PR TITLE
Add call dimension to metric for ShardSyncTask addSuccessAndLatency

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/metrics/MetricsCollectingTaskDecorator.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/metrics/MetricsCollectingTaskDecorator.java
@@ -52,6 +52,7 @@ public class MetricsCollectingTaskDecorator implements ConsumerTask {
         try {
             result = other.call();
         } finally {
+            MetricsUtil.addLatency(scope, other.getClass().getSimpleName(), startTimeMillis, MetricsLevel.SUMMARY);
             MetricsUtil.addSuccessAndLatency(scope, result != null && result.getException() == null, startTimeMillis,
                     MetricsLevel.SUMMARY);
             MetricsUtil.endScope(scope);


### PR DESCRIPTION
## Changes
* Add call dimension
* Dimension used to separate Time metric which is being double counted currently