### PR TITLE
search child shards in DDB instead of in local cache

### DIFF
--- a/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownTask.java
+++ b/amazon-kinesis-client/src/main/java/software/amazon/kinesis/lifecycle/ShutdownTask.java
@@ -246,7 +246,7 @@ public class ShutdownTask implements ConsumerTask {
             throws DependencyException, InvalidStateException, ProvisionedThroughputException {
         for(ChildShard childShard : childShards) {
             final String leaseKey = ShardInfo.getLeaseKey(shardInfo, childShard.shardId());
-            if(leaseCoordinator.getCurrentlyHeldLease(leaseKey) == null) {
+            if(leaseCoordinator.leaseRefresher().getLease(leaseKey) == null) {
                 final Lease leaseToCreate = hierarchicalShardSyncer.createLeaseForChildShard(childShard, shardDetector.streamIdentifier());
                 leaseCoordinator.leaseRefresher().createLeaseIfNotExists(leaseToCreate);
                 log.info("Shard {}: Created child shard lease: {}", shardInfo.shardId(), leaseToCreate.leaseKey());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In ShutdownTask, we should search the childShard in the DDB table instead of searching in the local cache because childShard can be processed by other worker.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
