### PR TITLE
Fixing cache miss bug in list shards

### DIFF
--- a/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisShardSyncer.java
@@ -169,7 +169,7 @@ class KinesisShardSyncer implements ShardSyncer {
 
         List<Shard> shards;
         if(CollectionUtils.isNullOrEmpty(latestShards)) {
-            shards = getShardListAtInitialPosition(kinesisProxy, initialPosition);
+            shards = isLeaseTableEmpty ? getShardListAtInitialPosition(kinesisProxy, initialPosition) : getCompleteShardList(kinesisProxy);
         } else {
             shards = latestShards;
         }


### PR DESCRIPTION
*Issue #, if available:*

Fixing bug in list shards, which caused PeriodicShardSync to only use a snapshot of shards, leaving the cache in a partial state until we hit a threshold of cache misses which unblocks KCL.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
